### PR TITLE
Fork Cromwell API and pare down to minimal common starting point

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -85,26 +85,6 @@ paths:
           required: true
           type: string
           in: path
-        - name: includeKey
-          description: >
-            When specified key(s) to include from the metadata. Matches any key starting with the value. May not be
-            used with excludeKey.
-          required: false
-          type: array
-          items:
-            type: string
-          collectionFormat: multi
-          in: query
-        - name: excludeKey
-          description: >
-            When specified key(s) to exclude from the metadata. Matches any key starting with the value. May not be
-            used with includeKey.
-          required: false
-          type: array
-          items:
-            type: string
-          collectionFormat: multi
-          in: query
       tags:
         - Workflows
       responses:


### PR DESCRIPTION
Forked from https://github.com/broadinstitute/cromwell/blob/947f8c60323a4e0fa89ebaff9337dd7e52f7c476/engine/src/main/resources/swagger/cromwell.yaml

Context: https://docs.google.com/document/d/19KMrx3yvCHDyM0KHkZRyK47W2D48C8-EiETlMIRVFfQ/edit#

Notes:
- To the best of my understanding, this proposal is a subset of the Cromwell API.
- See the second commit for a diff between this API and Cromwell
- Omitting the auth details from the Swagger until there's a working proof of concept over multiple backends
- Changed the "failures" message; the current Cromwell swagger API seems to not match the reality of the API so this should not actually be a breaking change (though it is a subset since Cromwell failures can be nested).
- Somewhat arbitrarily supporting query by POST (not GET) to avoid having both; this should be cleaned up later.
- Omitting PATCH labels for now, we can't implement for dsub and it's unclear if this functionality will be needed in the initial wireframes