### PR TITLE
Add parentId query support and label responses

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -239,8 +239,10 @@ definitions:
         format: string
         description: >
           Returns only workflows with the given parent ID. This parameter may be
-          unsupported for some API implementations or required for others. If
-          the presence of this parameter is incompatible with the server, it may
+          unsupported for some API implementations or required for others
+          depending on whether there exists a logical noun above a workflow
+          in the resource hierarchy (for example, a cloud project). If the
+          presence of this parameter is incompatible with the server, it may
           return a 400 HTTP status.
   WorkflowQueryResponse:
     description: Response to a workflow query


### PR DESCRIPTION
Builds on #1. Mostly non-breaking API changes with the existing Cromwell API.

- Parent ID query support will be required for implementing a dsub-based backend (cloud project ID). There are no plans to support this for the Cromwell backend.
- Labels in the response will be required to implement the proposed Job Monitor UI

The only thing here that could be considered breaking is the addition of labels to the workflow query response. Cromwell currently does not return this.