### PR TITLE
Add DSubClient layer for interacting with dstat and ddel

### DIFF
--- a/servers/dsub/jobs/__main__.py
+++ b/servers/dsub/jobs/__main__.py
@@ -4,7 +4,6 @@ import argparse
 import connexion
 import logging
 import os
-from flask_cors import CORS
 from .encoder import JSONEncoder
 
 app = connexion.App(__name__, specification_dir='./swagger/', swagger_ui=False)

--- a/servers/dsub/jobs/common/__init__.py
+++ b/servers/dsub/jobs/common/__init__.py
@@ -1,0 +1,3 @@
+def enum(**enums):
+    """Enable use of enums by utilizing types"""
+    return type('Enum', (), enums)

--- a/servers/dsub/jobs/dsub_client.py
+++ b/servers/dsub/jobs/dsub_client.py
@@ -1,0 +1,143 @@
+from dsub.providers import local
+from dsub.providers import google
+from dsub.providers import stub
+from dsub.commands import dstat
+from dsub.commands import ddel
+from jobs.common import enum
+
+ProviderType = enum(GOOGLE=0, LOCAL=1, STUB=2, UNKNOWN=3)
+
+
+class ConflictingId(Exception):
+    pass
+
+
+class DoesNotExist(Exception):
+    pass
+
+
+class DSubClient:
+    """Light dsub wrapper which enables easy execution of dstat + ddel commands"""
+
+    # TODO(bryancrampton) Once dsub exposes valid statuses update this map
+    # to use the constant/enum https://github.com/googlegenomics/dsub/issues/66
+    STATUS_MAP = {
+        'Submitted': 'RUNNING',
+        'Running': 'RUNNING',
+        'Aborting': 'RUNNING',
+        'Aborted': 'CANCELED',
+        'Succeeded': 'SUCCESS',
+        'Failed': 'FAILURE',
+    }
+
+    PROVIDER_MAP = {
+        local.LocalJobProvider: ProviderType.LOCAL,
+        google.GoogleJobProvider: ProviderType.GOOGLE,
+        stub.StubJobProvider: ProviderType.STUB,
+    }
+
+    # TODO(bryancrampton) support injecting credentials for Google provider type
+
+    def get_job(self, provider, job_id, task_id):
+        """Get metadata for a particular dsub job or task (if it exists).
+
+        Args:
+            provider (JobProvider): dsub provider to monitor and abort tasks
+            job_id (str): dsub job-id
+            tasK_id (str): dsub task-id (usually task-N)
+
+        Note:
+            See https://github.com/googlegenomics/dsub#viewing-job-status for
+            a description of dsub job-id and task-id formats
+
+        Returns:
+            dict: raw JSON metadata for the job or task
+        Raises:
+            ConflictingId: If multiple tasks are found with the same job-id and
+                           task-id
+            DoesNotExist: If no tasks exist with the given job-id and task-id
+
+        """
+        # dstat_job_producer returns a generator of lists of task dictionaries.
+        # poll_interval is implicitly set to 0 so there should be a single list.
+        jobs = dstat.dstat_job_producer(
+            provider=provider,
+            status_list=['*'],
+            job_list=[job_id],
+            task_list=[task_id],
+            raw_format=True).next()
+
+        # A job_id and task_id define a unique job (should only be one)
+        if len(jobs) > 1:
+            raise ConflictingId('Found more than one job with ID {}:{}'.format(
+                job_id, task_id))
+        elif len(jobs) == 0:
+            raise DoesNotExist('Could not find any jobs with ID {}:{}'.format(
+                job_id, task_id))
+
+        return jobs[0]
+
+    def abort_job(self, provider, job_id, task_id):
+        """Abort the dsub job or task (if it exists).
+
+        Args:
+            provider (JobProvider): dsub provider to monitor and abort tasks
+            job_id (str): dsub job-id
+            tasK_id (str): dsub task-id (usually task-N)
+
+        Returns:
+            dict: raw JSON metadata for the aborted job or task
+        Raises:
+            ConflictingId: If multiple tasks are found with the same job-id and
+                           task-id
+            DoesNotExist: If no tasks exist with the given job-id and task-id
+        """
+
+        jobs = ddel.ddel_tasks(
+            provider=provider, job_list=[job_id], task_list=[task_id])
+        if len(jobs) > 1:
+            raise ConflictingId(
+                "Found more than one job with ID:{}.".format(id))
+        elif len(jobs) == 0:
+            raise DoesNotExist('Could not find any jobs with ID {}:{}'.format(
+                job_id, task_id))
+
+        return jobs[0]
+
+    def query_jobs(self, provider, query):
+        """Query dsub jobs or tasks based on their metadata
+
+        Args:
+            params (JobQueryRequest): defined in swagger API spec
+
+        Returns:
+            list<dict>: A list of raw metadata for all jobs matching the query.
+        """
+        dstat_params = self._query_parameters(query)
+
+        # TODO(bryancrampton) support 'end_time' query parameter either within
+        # dsub or by filtering results after the fact
+
+        jobs = dstat.dstat_job_producer(
+            provider=provider,
+            status_list=dstat_params['statuses'],
+            create_time=dstat_params['create_time'],
+            job_name_list=dstat_params['job_name_list'],
+            raw_format=True).next()
+        return jobs
+
+    def _query_parameters(self, query):
+        dstat_params = {
+            'create_time': query.start,
+            'end_time': query.end,
+            'job_name_list': [query.name] if query.name else None,
+            'statuses': None,
+        }
+
+        if query.statuses:
+            # Flask validator of API spec ensures only valid statuses are
+            # passed as parameters so these should always exist in STATUS_MAP
+            status_set = set(query.statuses)
+            dstat_params['statuses'] = [self.STATUS_MAP[s] for s in status_set]
+
+        return dstat_params

--- a/servers/dsub/jobs/test/test_dsub_client.py
+++ b/servers/dsub/jobs/test/test_dsub_client.py
@@ -1,0 +1,160 @@
+from __future__ import absolute_import
+
+from jobs.models.job_query_request import JobQueryRequest
+from unittest import TestCase
+from dsub.providers import base
+from dsub.providers import stub
+from jobs.dsub_client import *
+from mock import MagicMock
+
+
+class TestDSubClient(TestCase):
+    """ DSubClient unit tests."""
+    OPS = [{
+        'job-id': 'job-1',
+        'job-name': 'foo',
+        'task-id': 'task-1',
+        'status': ('RUNNING', '123'),
+        'labels': {
+            'a_key': 'a_val'
+        }
+    }, {
+        'job-id': 'job-1',
+        'job-name': 'foo',
+        'task-id': 'task-2',
+        'status': ('FAILURE', '234'),
+        'labels': {
+            'some_key': 'some_value'
+        }
+    }, {
+        'job-id': 'job-2',
+        'job-name': 'bar',
+        'task-id': 'task-1',
+        'status': ('CANCELED', '345'),
+        'labels': {
+            'different_key': 'some_other_value'
+        }
+    }, {
+        'job-id': 'job-2',
+        'job-name': 'bar',
+        'task-id': 'task-2',
+        'status': ('RUNNING', '456'),
+        'labels': {
+            'another_key': 'a_third_value'
+        }
+    }, {
+        'job-id': 'job-2',
+        'job-name': 'bar',
+        'task-id': 'task-3',
+        'status': ('RUNNING', '567'),
+        'labels': {
+            'key4': 'val4'
+        }
+    }, {
+        'job-id': 'job-2',
+        'job-name': 'bar',
+        'task-id': 'task-4',
+        'status': ('RUNNING', '678'),
+        'labels': {
+            'key5': 'val5'
+        }
+    }, {
+        'job-id': 'job-2',
+        'job-name': 'bar',
+        'task-id': 'task-5',
+        'status': ('RUNNING', '789'),
+        'labels': {
+            'key6': 'val6'
+        }
+    }]
+
+    PROVIDER = stub.StubJobProvider()
+    CLIENT = DSubClient()
+
+    def setUp(self):
+        self.PROVIDER.set_operations(self.OPS)
+        super(TestDSubClient, self).setUp()
+
+    def tearDown(self):
+        # Reset any methods which are mocked in tests
+        self.PROVIDER.delete_jobs.reset_mock()
+        super(TestDSubClient, self).tearDown()
+
+    def test_get_job(self):
+        t1 = self.CLIENT.get_job(self.PROVIDER, 'job-1', 'task-1')
+        t2 = self.CLIENT.get_job(self.PROVIDER, 'job-1', 'task-2')
+        t3 = self.CLIENT.get_job(self.PROVIDER, 'job-2', 'task-1')
+        t4 = self.CLIENT.get_job(self.PROVIDER, 'job-2', 'task-2')
+        t5 = self.CLIENT.get_job(self.PROVIDER, 'job-2', 'task-3')
+        t6 = self.CLIENT.get_job(self.PROVIDER, 'job-2', 'task-4')
+        t7 = self.CLIENT.get_job(self.PROVIDER, 'job-2', 'task-5')
+        self.assertEqual([t1, t2, t3, t4, t5, t6, t7], self.OPS)
+
+    def test_get_job_conflicting_id(self):
+        self.PROVIDER.set_operations([{
+            'job-id': 'job-1',
+            'job-name': 'foo',
+            'task-id': 'task-1',
+            'status': ('FAILURE', '234'),
+            'labels': {
+                'some_key': 'some_value'
+            }
+        }, {
+            'job-id': 'job-1',
+            'job-name': 'foo',
+            'task-id': 'task-1',
+            'status': ('CANCELED', '345'),
+            'labels': {
+                'different_key': 'some_other_value'
+            }
+        }])
+        with self.assertRaises(ConflictingId):
+            self.CLIENT.get_job(self.PROVIDER, 'job-1', 'task-1')
+
+    def test_get_job_does_not_exist(self):
+        with self.assertRaises(DoesNotExist):
+            self.CLIENT.get_job(self.PROVIDER, 'missing', 'task-1')
+
+    def test_abort_job(self):
+        # We can remove this mock if this issue is resolved:
+        # https://github.com/googlegenomics/dsub/issues/65
+        self.PROVIDER.delete_jobs = MagicMock(return_value=(self.OPS[1:2], []))
+        self.CLIENT.abort_job(self.PROVIDER, 'job-1', 'task-2')
+        self.PROVIDER.delete_jobs.assert_called_with(None, ['job-1'],
+                                                     ['task-2'], None, None)
+
+    def test_abort_job_does_not_exist(self):
+        with self.assertRaises(DoesNotExist):
+            self.CLIENT.get_job(self.PROVIDER, 'nope', 'task-1')
+
+    def test_query_job_by_name(self):
+        tasks_named_foo = self.CLIENT.query_jobs(
+            self.PROVIDER, JobQueryRequest(name='foo'))
+        tasks_named_bar = self.CLIENT.query_jobs(
+            self.PROVIDER, JobQueryRequest(name='bar'))
+        tasks_named_blah = self.CLIENT.query_jobs(
+            self.PROVIDER, JobQueryRequest(name='blah'))
+        self.assertEqual(tasks_named_foo, self.OPS[0:2])
+        self.assertEqual(tasks_named_bar, self.OPS[2:])
+        self.assertEqual(tasks_named_blah, [])
+
+    def test_query_job_by_status(self):
+        running_tasks = self.CLIENT.query_jobs(
+            self.PROVIDER, JobQueryRequest(statuses=['Running']))
+        aborted_tasks = self.CLIENT.query_jobs(
+            self.PROVIDER, JobQueryRequest(statuses=['Aborted']))
+        failed_tasks = self.CLIENT.query_jobs(
+            self.PROVIDER, JobQueryRequest(statuses=['Failed']))
+        self.assertEqual(running_tasks, [
+            self.OPS[0], self.OPS[3], self.OPS[4], self.OPS[5], self.OPS[6]
+        ])
+        self.assertEqual(aborted_tasks, [self.OPS[2]])
+        self.assertEqual(failed_tasks, [self.OPS[1]])
+
+    # TODO(bryancrampton) Add support to dsub's StubJobProvider for lookup
+    # by create_time and job_name_list and add tests around that here
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()

--- a/servers/dsub/jobs/test/test_jobs_controller.py
+++ b/servers/dsub/jobs/test/test_jobs_controller.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from jobs.models.job_abort_response import JobAbortResponse
 from jobs.models.job_metadata_response import JobMetadataResponse
-from jobs.models.job_query_parameter import JobQueryParameter
+from jobs.models.job_query_request import JobQueryRequest
 from jobs.models.job_query_response import JobQueryResponse
 from . import BaseTestCase
 from six import BytesIO

--- a/servers/dsub/requirements-to-freeze.txt
+++ b/servers/dsub/requirements-to-freeze.txt
@@ -1,3 +1,4 @@
 connexion == 1.1.13
 gunicorn == 19.7.1
-dsub
+# TODO(bryancrampton): Update this once a new version of dsub is released
+-e git+https://github.com/bfcrampton/dsub.git#egg=dsub

--- a/servers/dsub/requirements.txt
+++ b/servers/dsub/requirements.txt
@@ -3,7 +3,7 @@ chardet==3.0.4
 click==6.7
 clickclick==1.2.2
 connexion==1.1.13
-dsub==0.0.0
+-e git+https://github.com/bfcrampton/dsub.git#egg=dsub
 Flask==0.12.2
 functools32==3.2.3.post2
 google-api-python-client==1.6.3
@@ -24,6 +24,7 @@ python-dateutil==2.6.1
 pytz==2017.2
 PyYAML==3.12
 requests==2.18.4
+retrying==1.3.3
 rsa==3.4.2
 six==1.10.0
 swagger-spec-validator==2.1.0

--- a/servers/dsub/test-requirements.txt
+++ b/servers/dsub/test-requirements.txt
@@ -3,3 +3,4 @@ coverage>=4.0.3
 nose>=1.3.7
 pluggy>=0.3.1
 py>=1.4.31
+mock == 2.0.0


### PR DESCRIPTION
Added minimal `DSubClient` which supports easy execution of `dstat` and `ddel` commands.

After additional thought on this I removed the functionality from the client to parse API Job IDs into its component 'dsub IDs'. The Job ID format is described in [this bug](https://b.corp.google.com/issues/63798365#comment9) and is essentially:
```
<gcp-project-id>:<dsub-job-id>:<dsub-task-id> # For Google job provider
<dsub-job-id>:<dsub-task-id> # For all other job providers (no concept of project-id)
```
I am leaving the responsibility of parsing these API Job ID formats and creating the necessary job provider (which for Google is dependent on `project-id`) to the `jobs_controller`. I think this is a cleaner separation of functionality and enables easier dependency injection into `DSubClient`.

### Merge First 🚫 : 
- [x] #5 
- [x] #11 
- [x] #7 