### PR TITLE
Add yapf linter as pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 
 Job Monitor API and UI for interacting with asynchronous batch jobs and
 workflows.
+
+## Setup Lint Git Hook:
+```
+sudo pip install yapf
+ln -s -f ../../hooks/pre-commit .git/hooks/pre-commit
+```

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Allows us to read user input below, assigns stdin to keyboard
+exec < /dev/tty
+status=0
+
+readonly changed_files_command="git diff --cached --name-only | grep '\.py$' | grep -v 'servers/dsub/jobs/models' | grep -v 'setup.py'"
+readonly files_in_commit=$(eval $changed_files_command)
+if [ -n "$files_in_commit" ]; then
+	# Stash un-staged changes to ensure that the staged changes pass the linter
+	git stash -q --keep-index
+	readonly LINT_OUT=$(yapf -d $files_in_commit)
+	# Pop the un-staged changes once the lint is complete
+	git stash pop -q
+
+	if [ -z "$LINT_OUT" ]; then
+		echo "Passed yapf linter!"
+	else
+		echo "Please use yapf lint your changed files by running the command below (and stage the changes after):"
+		echo "yapf -i \$($changed_files_command)"
+
+		read -r -p "Would you like to run it now? [y/N] " res
+		if [[ $res == "y" || $res == "Y" || $res == "yes" || $res == "Yes" ]]; then
+			yapf -i $files_in_commit
+		fi
+		# Prevent commit of non-linted files
+		status=1
+	fi
+fi
+
+# Close stdin and exit with the correct status
+exec <&-
+exit $status


### PR DESCRIPTION
[Copied](https://github.com/bvprivate/data-explorer-service/blob/master/hooks/pre-commit) from the data-explorer service

We don't have any python files yet, but I will run `yapf` on my open PRs so we don't check in un-linted code.