### PR TITLE
Update /jobs/query parameters to standard style

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -11,6 +11,7 @@ produces:
 paths:
   '/jobs/{id}/abort':
     post:
+      operationId: AbortJob
       summary: Abort a job by ID
       parameters:
         - name: id
@@ -33,18 +34,14 @@ paths:
           description: Internal Error
   '/jobs/query':
     post:
+      operationId: QueryJobs
       summary: Query jobs by start dates, end dates, names, ids, or statuses.
       parameters:
         - name: parameters
           required: true
           in: body
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/JobQueryParameter'
-          description: >
-            Same query parameters as GET /query endpoint, submitted as a json list.
-            Example: [{"status":"Success"},{"status":"Failed"}]
+            $ref: '#/definitions/JobQueryRequest'
       responses:
         '200':
           description: Successful Request
@@ -56,6 +53,7 @@ paths:
           description: Internal Error
   '/jobs/{id}':
     get:
+      operationId: GetJob
       summary: Query for job and task-level metadata for a specified job
       parameters:
         - name: id
@@ -175,10 +173,8 @@ definitions:
         type: string
         format: date-time
         description: The time at which this failure occurred
-  JobQueryParameter:
+  JobQueryRequest:
     description: Job query parameters
-    minProperties: 1
-    maxProperties: 1
     properties:
       start:
         type: string
@@ -192,15 +188,17 @@ definitions:
         description: >
           Returns only jobs with an equal or earlier end datetime.  Can be specified at most once.
           If both start and end date are specified, start date must be before or equal to end date.
-      status:
-        type: string
-        enum:
-          - Submitted
-          - Running
-          - Aborting
-          - Failed
-          - Succeeded
-          - Aborted
+      statuses:
+        type: array
+        items:
+          type: string
+          enum:
+            - Submitted
+            - Running
+            - Aborting
+            - Failed
+            - Succeeded
+            - Aborted
         description: >
           Returns only jobs with the specified status.  If specified multiple times,
           returns jobs in any of the specified statuses.


### PR DESCRIPTION
- Add `operationId` to each endpoint
- Update query parameters to take in a single `JobQueryParameter` instead an array of them
  - Update `JobQueryParameter` definition to support an array of statuses