### PR TITLE
Implement API with DSubClient 

### DIFF
--- a/Dockerfile.dsub
+++ b/Dockerfile.dsub
@@ -11,6 +11,16 @@ ADD servers/dsub/requirements.txt /app/
 RUN pip install -r requirements.txt
 ADD servers/dsub/jobs /app/jobs
 
+# Install docker-ce for dsub local provider
+RUN apt-get update
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install -y apt-utils apt-transport-https ca-certificates curl gnupg2 software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
+RUN apt-get update
+RUN apt-get install -y docker-ce
+
 # Missing required arguments -b PORT, -e ... which must be provided by the
 # docker image user.
 ENTRYPOINT ["/env/bin/gunicorn", "jobs.__main__:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '2'
 services:
   jobs:
+    # dsub creates the local provider folder in /tmp/dsub-local which can only
+    # be written to by the owner. Unless dsub changes the permissions on this
+    # folder the docker container must be 'privileged'
+    privileged: true
+    # This shares the host PID address space with the container so that host
+    # processes can be checked on and killed
+    pid: host
     build:
       context: .
       dockerfile: Dockerfile.dsub
@@ -8,6 +15,7 @@ services:
     # http://docs.gunicorn.org/en/stable/run.html#commonly-used-arguments
     command: ["-b", ":8190"]
     environment:
+      - PROVIDER_TYPE=local
       # Avoid writing .pyc files back to the volume. Files generated this way
       # have restricted permissions set which cause errors on subsequent docker
       # builds.
@@ -16,5 +24,7 @@ services:
       # Mount the python source so that code changes don't require rebuilding
       # the image. Changes to requirements.txt will still require rebuilds.
       - ./servers/dsub/jobs:/app/jobs
+      - /tmp/dsub-local:/tmp/dsub-local
+      - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - 8190:8190

--- a/servers/dsub/jobs/__main__.py
+++ b/servers/dsub/jobs/__main__.py
@@ -5,6 +5,7 @@ import connexion
 import logging
 import os
 from .encoder import JSONEncoder
+from controllers.dsub_client import DSubClient
 
 app = connexion.App(__name__, specification_dir='./swagger/', swagger_ui=False)
 app.app.json_encoder = JSONEncoder
@@ -20,6 +21,12 @@ app.app.logger.setLevel(logging.INFO)
 # values. These arguments will rarely be specified as flags directly, aside from
 # occasional use during local debugging.
 parser = argparse.ArgumentParser()
+parser.add_argument(
+    '--provider_type',
+    type=str,
+    help='The dsub provider type to use for monitoring jobs',
+    default=os.environ.get('PROVIDER_TYPE'))
+
 if __name__ == '__main__':
     parser.add_argument(
         '--port',
@@ -31,6 +38,9 @@ else:
     # Allow unknown args if we aren't the main program, these include flags to
     # gunicorn.
     args, _ = parser.parse_known_args()
+
+app.app.config['PROVIDER_TYPE'] = args.provider_type
+app.app.config['CLIENT'] = DSubClient()
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=args.port)

--- a/servers/dsub/jobs/controllers/dsub_client.py
+++ b/servers/dsub/jobs/controllers/dsub_client.py
@@ -1,40 +1,19 @@
+import connexion
+from werkzeug.exceptions import BadRequest
 from dsub.providers import local
 from dsub.providers import google
 from dsub.providers import stub
 from dsub.commands import dstat
 from dsub.commands import ddel
 from jobs.common import enum
+from errors import *
+import job_statuses
 
-ProviderType = enum(GOOGLE=0, LOCAL=1, STUB=2, UNKNOWN=3)
-
-
-class ConflictingId(Exception):
-    pass
-
-
-class DoesNotExist(Exception):
-    pass
+ProviderType = enum(GOOGLE='google', LOCAL='local', STUB='stub')
 
 
 class DSubClient:
     """Light dsub wrapper which enables easy execution of dstat + ddel commands"""
-
-    # TODO(bryancrampton) Once dsub exposes valid statuses update this map
-    # to use the constant/enum https://github.com/googlegenomics/dsub/issues/66
-    STATUS_MAP = {
-        'Submitted': 'RUNNING',
-        'Running': 'RUNNING',
-        'Aborting': 'RUNNING',
-        'Aborted': 'CANCELED',
-        'Succeeded': 'SUCCESS',
-        'Failed': 'FAILURE',
-    }
-
-    PROVIDER_MAP = {
-        local.LocalJobProvider: ProviderType.LOCAL,
-        google.GoogleJobProvider: ProviderType.GOOGLE,
-        stub.StubJobProvider: ProviderType.STUB,
-    }
 
     # TODO(bryancrampton) support injecting credentials for Google provider type
 
@@ -52,27 +31,25 @@ class DSubClient:
 
         Returns:
             dict: raw JSON metadata for the job or task
-        Raises:
-            ConflictingId: If multiple tasks are found with the same job-id and
-                           task-id
-            DoesNotExist: If no tasks exist with the given job-id and task-id
-
         """
+        # If task-id is not specified, pass None instead of [None]
+        task_list = [task_id] if task_id else None
+
         # dstat_job_producer returns a generator of lists of task dictionaries.
         # poll_interval is implicitly set to 0 so there should be a single list.
         jobs = dstat.dstat_job_producer(
             provider=provider,
             status_list=['*'],
             job_list=[job_id],
-            task_list=[task_id],
-            raw_format=True).next()
+            task_list=task_list,
+            full_output=True).next()
 
         # A job_id and task_id define a unique job (should only be one)
         if len(jobs) > 1:
-            raise ConflictingId('Found more than one job with ID {}:{}'.format(
+            raise BadRequest('Found more than one job with ID {}:{}'.format(
                 job_id, task_id))
         elif len(jobs) == 0:
-            raise DoesNotExist('Could not find any jobs with ID {}:{}'.format(
+            raise JobNotFound('Could not find any jobs with ID {}:{}'.format(
                 job_id, task_id))
 
         return jobs[0]
@@ -87,43 +64,40 @@ class DSubClient:
 
         Returns:
             dict: raw JSON metadata for the aborted job or task
-        Raises:
-            ConflictingId: If multiple tasks are found with the same job-id and
-                           task-id
-            DoesNotExist: If no tasks exist with the given job-id and task-id
         """
+        # If task-id is not specified, pass None instead of [None]
+        task_list = [task_id] if task_id else None
 
-        jobs = ddel.ddel_tasks(
-            provider=provider, job_list=[job_id], task_list=[task_id])
-        if len(jobs) > 1:
-            raise ConflictingId(
-                "Found more than one job with ID:{}.".format(id))
-        elif len(jobs) == 0:
-            raise DoesNotExist('Could not find any jobs with ID {}:{}'.format(
-                job_id, task_id))
-
-        return jobs[0]
+        # TODO(bryancrampton) Add flag to ddel to support deleting only
+        # 'singleton' tasks. For now, this will raise an error if more than one
+        # jobs or no jobs are found for the given job-id and task-id
+        self.get_job(provider, job_id, task_id)
+        tasks = ddel.ddel_tasks(
+            provider=provider, job_list=[job_id], task_list=task_list)
 
     def query_jobs(self, provider, query):
         """Query dsub jobs or tasks based on their metadata
 
         Args:
-            params (JobQueryRequest): defined in swagger API spec
+            params (QueryJobsRequest): defined in swagger API spec
 
         Returns:
             list<dict>: A list of raw metadata for all jobs matching the query.
         """
         dstat_params = self._query_parameters(query)
 
-        # TODO(bryancrampton) support 'end_time' query parameter either within
-        # dsub or by filtering results after the fact
+        # TODO(bryancrampton) support 'end_time' query parameter. First update
+        # to filter by end_time once dsub LocalJobsProvider supports it.
+        # https://github.com/googlegenomics/dsub/issues/67
+        # Eventually, the pipelines API and dsub should support this query .
 
         jobs = dstat.dstat_job_producer(
             provider=provider,
             status_list=dstat_params['statuses'],
             create_time=dstat_params['create_time'],
             job_name_list=dstat_params['job_name_list'],
-            raw_format=True).next()
+            full_output=True).next()
+
         return jobs
 
     def _query_parameters(self, query):
@@ -135,9 +109,9 @@ class DSubClient:
         }
 
         if query.statuses:
-            # Flask validator of API spec ensures only valid statuses are
-            # passed as parameters so these should always exist in STATUS_MAP
             status_set = set(query.statuses)
-            dstat_params['statuses'] = [self.STATUS_MAP[s] for s in status_set]
+            dstat_params['statuses'] = [
+                job_statuses.api_to_dsub(s) for s in status_set
+            ]
 
         return dstat_params

--- a/servers/dsub/jobs/controllers/errors.py
+++ b/servers/dsub/jobs/controllers/errors.py
@@ -1,0 +1,6 @@
+from werkzeug.exceptions import NotFound
+
+
+class JobNotFound(NotFound):
+    def __init__(self, job_id, **kwargs):
+        NotFound.__init__(self, '"job {}" not found'.format(job_id), **kwargs)

--- a/servers/dsub/jobs/controllers/job_ids.py
+++ b/servers/dsub/jobs/controllers/job_ids.py
@@ -1,0 +1,73 @@
+from dsub_client import DSubClient, ProviderType
+from werkzeug.exceptions import BadRequest
+
+
+def api_to_dsub(api_id, provider_type):
+    """Convert an API ID and provider type to dsub project, job, and task IDs
+
+      Args:
+          api_id (str): The API ID corresponding to a particular dsub task. 
+              Depending on the provider and semantics of the job, the ID can 
+              have one of four possible schemas described in comments below.
+          provider_type (ProviderType): The dsub provider currently being used.
+              Currently the options are google, local, or stub
+                
+      Returns:
+          (str, str, str): dsub project, job, task IDs respectively. The job ID
+              will never be None, but both project ID and task ID can be
+          
+      Raises:
+          BadRequest if the api_id format is invalid for the given provider
+    """
+    project, job, task = None, None, None
+    id_split = api_id.split(":")
+
+    if provider_type == ProviderType.GOOGLE:
+        # If we are running on Google cloud the id format should be:
+        # <project-id>:<job-id>:<task-id> or <project-id>:<job-id> if there is
+        # no task ID
+        if len(id_split) == 2:
+            project, job = id_split
+        elif len(id_split) == 3:
+            project, job, task = id_split
+        else:
+            raise BadRequest('Job ID format for google provider is: ' +
+                             '<project-id>:<job-id>[:<task-id>]?')
+    else:
+        # Otherwise, the id format should be: <job-id>:<task-id> or <job-id> if
+        # there is no task ID
+        if len(id_split) == 1:
+            job = id_split[0]
+        elif len(id_split) == 2:
+            job, task = id_split
+        else:
+            raise BadRequest('Job ID format for non-google provider is: ' +
+                             '<job-id>[:<task-id>]?')
+
+    return project, job, task
+
+
+def dsub_to_api(proj_id, job_id, task_id):
+    """Convert a dsub project, job, and task IDs to an API ID
+
+      Args:
+          proj_id (str): dsub Google cloud project ID (google provider only)
+          job_id (str): dsub job ID (all providers)
+          task_id (str): dsub task ID (if job was started with multiple tasks)
+                
+      Returns:
+          (str): API ID formed by composition of one or more of the inputs
+          
+      Raises:
+          BadRequest if no job_id is provided
+    """
+    if proj_id and job_id and task_id:
+        return '{}:{}:{}'.format(proj_id, job_id, task_id)
+    elif proj_id and job_id:
+        return '{}:{}'.format(proj_id, job_id)
+    elif job_id and task_id:
+        return '{}:{}'.format(job_id, task_id)
+    elif job_id:
+        return job_id
+    else:
+        raise BadRequest('Invalid dsub ID format, no job_id was provided')

--- a/servers/dsub/jobs/controllers/job_statuses.py
+++ b/servers/dsub/jobs/controllers/job_statuses.py
@@ -1,0 +1,58 @@
+from werkzeug.exceptions import BadRequest
+
+# Once dsub exposes valid statuses update this to not be a manual map
+# https://github.com/googlegenomics/dsub/issues/66
+# Swagger-codegen does not generate an enum of constants for model definitions
+# so they are mapped them out manually as well
+# https://github.com/swagger-api/swagger-codegen/issues/6529
+
+API_STATUS_MAP = {
+    'Submitted': 'RUNNING',
+    'Running': 'RUNNING',
+    'Aborting': 'RUNNING',
+    'Aborted': 'CANCELED',
+    'Succeeded': 'SUCCESS',
+    'Failed': 'FAILURE',
+}
+
+DSUB_STATUS_MAP = {
+    'RUNNING': 'Running',
+    'CANCELED': 'Aborted',
+    'SUCCESS': 'Succeeded',
+    'FAILURE': 'Failed',
+}
+
+
+def dsub_to_api(dsub_status):
+    """Map an API status to a dsub status
+
+      Args:
+          dsub_status (str): 'RUNNING', 'CANCELED', 'SUCCESS', or 'FAILURE'
+
+      Returns:
+          str: api status 'Running', 'Aborted', 'Succeeded', or 'Failed'
+          
+      Raises:
+          BadRequest if the dsub_status is not valid
+    """
+    if dsub_status not in DSUB_STATUS_MAP:
+        raise BadRequest('Unrecognized dsub status:{}'.format(dsub_status))
+    return DSUB_STATUS_MAP[dsub_status]
+
+
+def api_to_dsub(api_status):
+    """Map a dsub status to an API status
+
+      Args:
+          api_status (str): 'Submitted', 'Running', 'Aborting', 'Aborted', 
+                            'Succeeded', or 'Failed'
+
+      Returns:
+          str: dsub status 'RUNNING', 'CANCELED', 'SUCCESS', or 'FAILURE'
+
+      Raises:
+          BadRequest if the api_status is not valid 
+    """
+    if api_status not in API_STATUS_MAP:
+        raise BadRequest('Unrecognized api status:{}'.format(api_status))
+    return API_STATUS_MAP[api_status]

--- a/servers/dsub/jobs/test/test_jobs_controller.py
+++ b/servers/dsub/jobs/test/test_jobs_controller.py
@@ -8,11 +8,13 @@ from jobs.models.query_jobs_response import QueryJobsResponse
 from . import BaseTestCase
 from six import BytesIO
 from flask import json
+import unittest
 
 
 class TestJobsController(BaseTestCase):
     """ DefaultController integration test stubs """
 
+    @unittest.skip("not implemented")
     def test_abort_job(self):
         """
         Test case for abort_job
@@ -24,6 +26,7 @@ class TestJobsController(BaseTestCase):
         self.assert200(response,
                        "Response body is : " + response.data.decode('utf-8'))
 
+    @unittest.skip("not implemented")
     def test_get_job(self):
         """
         Test case for get_job
@@ -35,6 +38,7 @@ class TestJobsController(BaseTestCase):
         self.assert200(response,
                        "Response body is : " + response.data.decode('utf-8'))
 
+    @unittest.skip("not implemented")
     def test_query_jobs(self):
         """
         Test case for query_jobs

--- a/servers/dsub/requirements.txt
+++ b/servers/dsub/requirements.txt
@@ -4,7 +4,7 @@ chardet==3.0.4
 click==6.7
 clickclick==1.2.2
 connexion==1.1.13
--e git+https://github.com/bfcrampton/dsub.git@0033f9f486ee70887d0a3c6ed97f81fab80d51cd#egg=dsub-master
+-e git+https://github.com/bfcrampton/dsub.git#egg=dsub-master
 Flask==0.12.2
 functools32==3.2.3-2
 google-api-python-client==1.6.4

--- a/servers/dsub/tox.ini
+++ b/servers/dsub/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27, py35
+envlist = py27
 
 [testenv]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-       
+
 commands=
    nosetests \
       []


### PR DESCRIPTION
Initial implementation of the API with a dsub shim resolves #3 

### Notes
- Install `docker` within the `jobs` docker-compose container to allow dsub local provider to execute
- Mount volumes `/tmp/dsub-local` and `/var/run/docker.sock` so that the container can access local dsub jobs running on the host
- Default to `local` provider, `google` is also also supported but there is currently no way to get credentials into the docker container

### Integration Testing
I will follow up with integration testing for local and google providers in a separate PR. Need to make some changes to `dsub` to allow submitting jobs via python.