### PR TITLE
Fix table text overflow behavior

### DIFF
--- a/ui/src/app/components/jobs-overview/table.component.css
+++ b/ui/src/app/components/jobs-overview/table.component.css
@@ -16,6 +16,10 @@
   vertical-align: middle;
   padding: 0 8px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 20rem;
 }
 
 .job-details-button {

--- a/ui/src/app/components/jobs-overview/table.component.ts
+++ b/ui/src/app/components/jobs-overview/table.component.ts
@@ -17,7 +17,6 @@ import 'rxjs/add/observable/fromEvent';
 import {JobStatus} from '../../model/JobStatus';
 import {QueryJobsResult} from '../../model/QueryJobsResult';
 import {JobStatusImage} from '../../app.component';
-import {JobMetadataResponse} from '../../model/JobMetadataResponse';
 
 @Component({
   selector: 'list-jobs',


### PR DESCRIPTION
Limit text to a single row to preserve the table view and overflow with ellipsis. The details page should be responsible for any full-text versions of this.