### PR TITLE
Fix datetime parsing for dsub local provider

### DIFF
--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -116,9 +116,8 @@ def _parse_datetime(d):
     elif provider_type() == ProviderType.GOOGLE:
         return datetime.strptime(d, '%Y-%m-%d %H:%M:%S').replace(
             tzinfo=tzlocal())
-    else:
-        return datetime.strptime(d, '%Y-%m-%d %H:%M:%S.%f').replace(
-            tzinfo=tzlocal())
+    return datetime.strptime(d, '%Y-%m-%d %H:%M:%S.%f').replace(
+        tzinfo=tzlocal())
 
 
 def _job_to_api_labels(job):


### PR DESCRIPTION
Per this bug: https://github.com/googlegenomics/dsub/issues/77 there are inconsistencies in the way `dstat` outputs timestamps. 

### Variations:
- For `GoogleJobProvider` all timestamps are formatted with the pattern (fixed in #62): [`%Y-%m-%d %H:%M:%S`](https://github.com/googlegenomics/dsub/blob/f639da55bb33529e002cc62f3a85c4a6b4af5cd3/dsub/providers/google.py#L1324)
- For `LocalJobProvider` the `create-time` timestamp (currently also `start-time`) is formatted with the pattern (fixed in this PR): [`%Y-%m-%d %H:%M:%S.%f`](https://github.com/googlegenomics/dsub/blob/f639da55bb33529e002cc62f3a85c4a6b4af5cd3/dsub/providers/local.py#L133)
- For `LocalJobProvider` the `last-update` timestamp is unformatted and returned as a `datetime` object
- For `StubJobProvider` there is no output formatting, so whatever type is passed into [`set_operations()`](https://github.com/googlegenomics/dsub/blob/f639da55bb33529e002cc62f3a85c4a6b4af5cd3/dsub/providers/stub.py#L42) will be returned (we don't currently set timestamps with the stub provider, but when we do we should set them to `datetime` objects).

Ideally dsub would return a `datetime` object for all timestamps in the python API, so that we don't have to parse a date string. Once this happens we can remove this conditional parsing logic.

