### PR TITLE
Modularize major features

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -7,13 +7,9 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {BrowserModule} from '@angular/platform-browser';
 import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
-import {JobListComponent} from './job-list/job-list.component';
-import {JobDetailsComponent} from './job-details/job-details.component';
-import {JobPanelsComponent} from './job-details/panels/panels.component';
-import {JobsTableComponent} from './job-list/table/table.component';
-import {TaskDetailsComponent} from './job-details/tasks/tasks.component';
-import {JobDetailsResolver} from './job-details/job-details-resolver.service';
 import {CoreModule} from './core/core.module';
+import {JobListModule} from './job-list/job-list.module';
+import {JobDetailsModule} from './job-details/job-details.module';
 
 @NgModule({
   imports: [
@@ -23,18 +19,10 @@ import {CoreModule} from './core/core.module';
     CoreModule,
     FormsModule,
     HttpModule,
+    JobDetailsModule,
+    JobListModule,
   ],
-  declarations: [
-    AppComponent,
-    JobDetailsComponent,
-    JobListComponent,
-    JobPanelsComponent,
-    JobsTableComponent,
-    TaskDetailsComponent,
-  ],
-  providers: [
-    JobDetailsResolver,
-  ],
+  declarations: [AppComponent],
   // This specifies the top-level component, to load first.
   bootstrap: [AppComponent]
 })

--- a/ui/src/app/core/core.module.ts
+++ b/ui/src/app/core/core.module.ts
@@ -1,38 +1,11 @@
 import {NgModule, Optional, SkipSelf} from '@angular/core';
 import {JobMonitorService} from './job-monitor.service';
-import {
-  MdButtonModule,
-  MdCardModule,
-  MdCheckboxModule,
-  MdExpansionModule,
-  MdIconModule,
-  MdInputModule,
-  MdMenuModule,
-  MdPaginatorModule,
-  MdSortModule,
-  MdTableModule,
-  MdTabsModule,
-  MdTooltipModule,
-} from '@angular/material';
 
 /** Provides all of the common singleton components and services that can be
  *  shared across the app and should only ever be instantiated once. */
 @NgModule({
   imports: [],
-  exports: [
-    MdButtonModule,
-    MdCardModule,
-    MdCheckboxModule,
-    MdExpansionModule,
-    MdIconModule,
-    MdInputModule,
-    MdMenuModule,
-    MdPaginatorModule,
-    MdSortModule,
-    MdTableModule,
-    MdTabsModule,
-    MdTooltipModule,
-  ],
+  exports: [],
   declarations: [],
   providers: [JobMonitorService]
 })

--- a/ui/src/app/job-details/job-details.module.ts
+++ b/ui/src/app/job-details/job-details.module.ts
@@ -1,0 +1,33 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {JobPanelsComponent} from './panels/panels.component';
+import {JobDetailsComponent} from './job-details.component';
+import {TaskDetailsComponent} from './tasks/tasks.component';
+import {
+  MdButtonModule,
+  MdCardModule,
+  MdMenuModule,
+  MdTableModule,
+  MdTabsModule,
+  MdTooltipModule,
+} from '@angular/material';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MdButtonModule,
+    MdCardModule,
+    MdMenuModule,
+    MdTableModule,
+    MdTabsModule,
+    MdTooltipModule,
+  ],
+  declarations: [
+    JobDetailsComponent,
+    JobPanelsComponent,
+    TaskDetailsComponent,
+  ],
+  providers: [],
+  exports: []
+})
+export class JobDetailsModule {}

--- a/ui/src/app/job-list/job-list.module.ts
+++ b/ui/src/app/job-list/job-list.module.ts
@@ -1,0 +1,42 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {JobDetailsResolver} from '../job-details/job-details-resolver.service';
+import {JobListComponent} from './job-list.component';
+import {JobsTableComponent} from './table/table.component';
+import {
+  MdButtonModule,
+  MdCardModule,
+  MdCheckboxModule,
+  MdInputModule,
+  MdMenuModule,
+  MdPaginatorModule,
+  MdSortModule,
+  MdTableModule,
+  MdTabsModule,
+  MdTooltipModule,
+} from '@angular/material';
+import {RouterModule} from '@angular/router';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MdButtonModule,
+    MdCardModule,
+    MdCheckboxModule,
+    MdInputModule,
+    MdMenuModule,
+    MdPaginatorModule,
+    MdSortModule,
+    MdTableModule,
+    MdTabsModule,
+    MdTooltipModule,
+    RouterModule,
+  ],
+  declarations: [
+    JobListComponent,
+    JobsTableComponent,
+  ],
+  providers: [JobDetailsResolver],
+  exports: []
+})
+export class JobListModule {}


### PR DESCRIPTION
Instead of dumping everything in the app module, modularize each major feature into a corresponding feature module which can then be imported into the app module or ported anywhere else. This keeps the app module as lean as possible. Each feature module also imports its own dependencies, making our code more modular.