### PR TITLE
Clean up typescript structure

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -1,12 +1,12 @@
-// Based on the URL mapping in "routes" below, the RouterModule attaches
-// UI Components to the <router-outlet> element in the main AppComponent.
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 
-import {JobListComponent} from './job-list/job-list.component';
 import {JobDetailsComponent} from './job-details/job-details.component';
 import {JobDetailsResolver} from './job-details/job-details-resolver.service';
+import {JobListComponent} from './job-list/job-list.component';
 
+// Based on the URL mapping in "routes" below, the RouterModule attaches
+// UI Components to the <router-outlet> element in the main AppComponent.
 const routes: Routes = [
   {path: '', redirectTo: '/jobs', pathMatch: 'full'},
   {path: 'jobs', component:JobListComponent},

--- a/ui/src/app/app.component.spec.ts
+++ b/ui/src/app/app.component.spec.ts
@@ -1,5 +1,7 @@
-import { TestBed, async } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import {TestBed, async} from '@angular/core/testing';
+
+import {AppComponent} from './app.component';
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: 'jm-app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,15 +1,14 @@
-import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
-import {
-  HttpModule, Http, BaseRequestOptions
-} from '@angular/http';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {BrowserModule} from '@angular/platform-browser';
+import {FormsModule} from '@angular/forms';
+import {HttpModule} from '@angular/http';
+import {NgModule} from '@angular/core';
+
 import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
 import {CoreModule} from './core/core.module';
-import {JobListModule} from './job-list/job-list.module';
 import {JobDetailsModule} from './job-details/job-details.module';
+import {JobListModule} from './job-list/job-list.module';
 
 @NgModule({
   imports: [

--- a/ui/src/app/core/core.module.ts
+++ b/ui/src/app/core/core.module.ts
@@ -1,6 +1,6 @@
 import {NgModule, Optional, SkipSelf} from '@angular/core';
+
 import {JobMonitorService} from './job-monitor.service';
-import {ShortDateTimePipe} from '../shared/short-date-time.pipe';
 
 /** Provides all of the common singleton components and services that can be
  *  shared across the app and should only ever be instantiated once. */

--- a/ui/src/app/core/job-monitor.service.ts
+++ b/ui/src/app/core/job-monitor.service.ts
@@ -1,12 +1,12 @@
-// Data interface for listing jobs. This
-// communicates via Angular's builtin Http module with a (fake) REST API.
-import 'rxjs/add/operator/toPromise';
-import {Injectable} from '@angular/core';
 import {Headers, Http, RequestOptions} from '@angular/http';
+import {Injectable} from '@angular/core';
+import 'rxjs/add/operator/toPromise';
+
+import {environment} from '../../environments/environment';
 import {QueryJobsRequest} from '../shared/model/QueryJobsRequest';
 import {QueryJobsResponse} from '../shared/model/QueryJobsResponse';
 import {JobMetadataResponse} from '../shared/model/JobMetadataResponse';
-import {environment} from '../../environments/environment';
+
 
 /** Service wrapper for accessing the job monitor API. */
 @Injectable()
@@ -14,40 +14,6 @@ export class JobMonitorService {
   private headers = new Headers({'Content-Type': 'application/json'});
 
   constructor(private http: Http) {}
-
-  queryJobs(req: QueryJobsRequest): Promise<QueryJobsResponse> {
-    return this.http.post(
-      `${environment.apiUrl}/jobs/query`,
-      req,
-      new RequestOptions({
-        headers: this.headers,
-      }))
-      .toPromise()
-      .then(response => this.convertToQueryJobsResponse(response.json()))
-      .catch(this.handleError);
-  }
-
-  abortJob(id: string): Promise<void> {
-    return this.http.post(`${environment.apiUrl}/jobs/${id}/abort`,
-      new RequestOptions({headers: this.headers}))
-      .toPromise()
-      .then(response => response.status == 200)
-      .catch(this.handleError);
-  }
-
-  getJob(id: string): Promise<JobMetadataResponse> {
-    return this.http.get(`${environment.apiUrl}/jobs/${id}`,
-      new RequestOptions({headers: this.headers}))
-      .toPromise()
-      .then(response => this.convertToJobMetadataResponse(response.json()))
-      .catch(this.handleError);
-  }
-
-  private handleError(error: any): Promise<any> {
-    // TODO(alahwa): Implement real error handling.
-    console.error('An error occurred', error);
-    return Promise.reject(error.message || error);
-  }
 
   private convertToJobMetadataResponse(json: object): JobMetadataResponse {
     var metadata: JobMetadataResponse = json as JobMetadataResponse;
@@ -73,5 +39,40 @@ export class JobMonitorService {
       }
     }
     return response;
+  }
+
+  private handleError(error: any): Promise<any> {
+    // TODO(alahwa): Implement real error handling.
+    console.error('An error occurred', error);
+    return Promise.reject(error.message || error);
+  }
+
+
+  abortJob(id: string): Promise<void> {
+    return this.http.post(`${environment.apiUrl}/jobs/${id}/abort`,
+      new RequestOptions({headers: this.headers}))
+      .toPromise()
+      .then(response => response.status == 200)
+      .catch(this.handleError);
+  }
+
+  getJob(id: string): Promise<JobMetadataResponse> {
+    return this.http.get(`${environment.apiUrl}/jobs/${id}`,
+      new RequestOptions({headers: this.headers}))
+      .toPromise()
+      .then(response => this.convertToJobMetadataResponse(response.json()))
+      .catch(this.handleError);
+  }
+
+  queryJobs(req: QueryJobsRequest): Promise<QueryJobsResponse> {
+    return this.http.post(
+      `${environment.apiUrl}/jobs/query`,
+      req,
+      new RequestOptions({
+        headers: this.headers,
+      }))
+      .toPromise()
+      .then(response => this.convertToQueryJobsResponse(response.json()))
+      .catch(this.handleError);
   }
 }

--- a/ui/src/app/core/search/search.component.ts
+++ b/ui/src/app/core/search/search.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 
 @Component({
-  selector: 'search',
+  selector: 'jm-search',
   templateUrl: './search.component.html',
   styleUrls: ['./search.component.css'],
 })

--- a/ui/src/app/job-details/job-details-resolver.service.ts
+++ b/ui/src/app/job-details/job-details-resolver.service.ts
@@ -1,8 +1,13 @@
+import {
+  ActivatedRouteSnapshot,
+  Router,
+  Resolve,
+  RouterStateSnapshot
+} from '@angular/router';
+import {Injectable} from '@angular/core';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/take';
-import { Injectable }             from '@angular/core';
-import { Router, Resolve, RouterStateSnapshot,
-  ActivatedRouteSnapshot } from '@angular/router';
+
 import {JobMetadataResponse} from '../shared/model/JobMetadataResponse';
 import {JobMonitorService} from '../core/job-monitor.service';
 

--- a/ui/src/app/job-details/job-details.component.html
+++ b/ui/src/app/job-details/job-details.component.html
@@ -1,3 +1,3 @@
-<panels [job]="job"></panels>
+<jm-panels [job]="job"></jm-panels>
 <!-- Only show the tasks table if there is at least 1 task. -->
-<tasks *ngIf="hasTasks()" [tasks]="job.tasks"></tasks>
+<jm-tasks *ngIf="hasTasks()" [tasks]="job.tasks"></jm-tasks>

--- a/ui/src/app/job-details/job-details.component.ts
+++ b/ui/src/app/job-details/job-details.component.ts
@@ -1,5 +1,6 @@
-import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
+import {Component, OnInit} from '@angular/core';
+
 import {JobMetadataResponse} from '../shared/model/JobMetadataResponse';
 import {TaskMetadata} from '../shared/model/TaskMetadata';
 

--- a/ui/src/app/job-details/job-details.module.ts
+++ b/ui/src/app/job-details/job-details.module.ts
@@ -1,8 +1,5 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {JobPanelsComponent} from './panels/panels.component';
-import {JobDetailsComponent} from './job-details.component';
-import {TaskDetailsComponent} from './tasks/tasks.component';
 import {
   MdButtonModule,
   MdCardModule,
@@ -11,7 +8,12 @@ import {
   MdTabsModule,
   MdTooltipModule,
 } from '@angular/material';
+
+import {JobDetailsComponent} from './job-details.component';
+import {JobPanelsComponent} from './panels/panels.component';
 import {SharedModule} from '../shared/shared.module';
+import {TaskDetailsComponent} from './tasks/tasks.component';
+
 
 @NgModule({
   imports: [

--- a/ui/src/app/job-details/panels/panels.component.ts
+++ b/ui/src/app/job-details/panels/panels.component.ts
@@ -1,25 +1,27 @@
 import {
-  Component, Input, OnChanges, SimpleChanges
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges
 } from '@angular/core';
+
 import {JobMetadataResponse} from '../../shared/model/JobMetadataResponse';
-import {TaskMetadata} from '../../shared/model/TaskMetadata';
 import {JobStatus} from '../../shared/model/JobStatus';
+import {TaskMetadata} from '../../shared/model/TaskMetadata';
 
 @Component({
-  selector: 'panels',
+  selector: 'jm-panels',
   templateUrl: './panels.component.html',
   styleUrls: ['./panels.component.css'],
 })
 export class JobPanelsComponent implements OnChanges {
   @Input() job: JobMetadataResponse;
-  tasks: TaskMetadata[];
+  gcsPrefix: string = "https://console.cloud.google.com/storage/browser/";
+  inputs: Array<String>;
   numCompletedTasks: number = 0;
   numTasks: number = 0;
-
-  gcsPrefix: string = "https://console.cloud.google.com/storage/browser/";
-
-  inputs: Array<String>;
   outputs: Array<String>;
+  tasks: TaskMetadata[];
 
   ngOnChanges(changes: SimpleChanges) {
     this.job = changes.job.currentValue;
@@ -48,14 +50,6 @@ export class JobPanelsComponent implements OnChanges {
       Math.round(duration/60000)%60 + "m";
   }
 
-  showInputsButton(): boolean {
-    return this.inputs.length > 0;
-  }
-
-  showOutputsButton(): boolean {
-    return this.outputs.length > 0;
-  }
-
   getInputResourceURL(key: string): string {
     return this.getResourceURL(this.job.inputs[key]);
   }
@@ -75,5 +69,13 @@ export class JobPanelsComponent implements OnChanges {
     // This is valid with wildcard glob (bucket/path/*) and directories
     // (bucket/path/dir/) as well, the * or empty string will be trimmed.
     return this.gcsPrefix + parts.slice(2,-1).join("/");
+  }
+
+  showInputsButton(): boolean {
+    return this.inputs.length > 0;
+  }
+
+  showOutputsButton(): boolean {
+    return this.outputs.length > 0;
   }
 }

--- a/ui/src/app/job-details/tasks/tasks.component.ts
+++ b/ui/src/app/job-details/tasks/tasks.component.ts
@@ -1,16 +1,20 @@
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {
-  Component, Input, OnChanges, OnInit,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
   SimpleChanges
 } from '@angular/core';
-import {TaskMetadata} from '../../shared/model/TaskMetadata';
 import {DataSource} from '@angular/cdk/collections';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Observable} from 'rxjs/Observable';
+
 import {JobStatus} from '../../shared/model/JobStatus';
 import {JobStatusImage} from '../../shared/common';
+import {TaskMetadata} from '../../shared/model/TaskMetadata';
 
 @Component({
-  selector: 'tasks',
+  selector: 'jm-tasks',
   templateUrl: './tasks.component.html',
   styleUrls: ['./tasks.component.css'],
 })

--- a/ui/src/app/job-list/job-list.component.html
+++ b/ui/src/app/job-list/job-list.component.html
@@ -1,1 +1,1 @@
-<job-list-table [jobs]="jobs" (updateJobs)="updateJobs($event)"></job-list-table>
+<jm-job-list-table [jobs]="jobs" (updateJobs)="updateJobs($event)"></jm-job-list-table>

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -1,9 +1,10 @@
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
+
 import {JobMonitorService} from '../core/job-monitor.service';
+import {JobStatus} from '../shared/model/JobStatus';
 import {QueryJobsResult} from '../shared/model/QueryJobsResult';
 import {StatusGroup} from './table/table.component';
-import {JobStatus} from '../shared/model/JobStatus';
 
 @Component({
   templateUrl: './job-list.component.html',
@@ -22,14 +23,6 @@ export class JobListComponent implements OnInit {
     this.updateJobs(StatusGroup.Active);
   }
 
-  private updateJobs(statusGroup: StatusGroup): void {
-    this.jobMonitorService.queryJobs({
-        parentId: this.route.snapshot.queryParams['parentId'],
-        statuses: this.statusGroupToJobStatuses(statusGroup)
-      })
-      .then(response => this.jobs = response.results);
-  }
-
   private statusGroupToJobStatuses(statusGroup: StatusGroup): JobStatus[] {
     switch(statusGroup) {
       case StatusGroup.Active: {
@@ -45,5 +38,13 @@ export class JobListComponent implements OnInit {
         return [];
       }
     }
+  }
+
+  private updateJobs(statusGroup: StatusGroup): void {
+    this.jobMonitorService.queryJobs({
+        parentId: this.route.snapshot.queryParams['parentId'],
+        statuses: this.statusGroupToJobStatuses(statusGroup)
+      })
+      .then(response => this.jobs = response.results);
   }
 }

--- a/ui/src/app/job-list/job-list.module.ts
+++ b/ui/src/app/job-list/job-list.module.ts
@@ -1,8 +1,4 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import {JobDetailsResolver} from '../job-details/job-details-resolver.service';
-import {JobListComponent} from './job-list.component';
-import {JobsTableComponent} from './table/table.component';
 import {
   MdButtonModule,
   MdCardModule,
@@ -15,7 +11,12 @@ import {
   MdTabsModule,
   MdTooltipModule,
 } from '@angular/material';
+import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
+
+import {JobDetailsResolver} from '../job-details/job-details-resolver.service';
+import {JobListComponent} from './job-list.component';
+import {JobsTableComponent} from './table/table.component';
 import {SharedModule} from '../shared/shared.module';
 
 @NgModule({

--- a/ui/src/app/shared/mock-job-monitor.service.ts
+++ b/ui/src/app/shared/mock-job-monitor.service.ts
@@ -1,7 +1,8 @@
 import {MockBackend, MockConnection} from '@angular/http/testing';
 import {ResponseOptions, Response} from '@angular/http';
-import {QueryJobsResult} from './model/QueryJobsResult';
+
 import {JobStatus} from './model/JobStatus';
+import {QueryJobsResult} from './model/QueryJobsResult';
 import {TaskMetadata} from './model/TaskMetadata';
 
 /**

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -1,5 +1,6 @@
-import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
 import {ShortDateTimePipe} from "./short-date-time.pipe";
 
 @NgModule({

--- a/ui/src/app/shared/short-date-time.pipe.ts
+++ b/ui/src/app/shared/short-date-time.pipe.ts
@@ -1,10 +1,17 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { DatePipe } from '@angular/common';
+import {DatePipe} from '@angular/common';
+import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'shortDateTime'
 })
 export class ShortDateTimePipe extends DatePipe implements PipeTransform {
+
+  isToday(date: Date): boolean {
+    let today: Date = new Date();
+    return date.getUTCDate() == today.getUTCDate() &&
+      date.getUTCMonth() == today.getUTCMonth() &&
+      date.getUTCFullYear() == today.getUTCFullYear();
+  }
 
   transform(date: Date): string {
     if (this.isToday(date)) {
@@ -13,12 +20,5 @@ export class ShortDateTimePipe extends DatePipe implements PipeTransform {
     return super.transform(date, 'MMM dd') +
       ' \u00B7 ' + // Middle dot
       super.transform(date, 'shortTime');
-  }
-
-  isToday(date: Date): boolean {
-    let today: Date = new Date();
-    return date.getUTCDate() == today.getUTCDate() &&
-        date.getUTCMonth() == today.getUTCMonth() &&
-        date.getUTCFullYear() == today.getUTCFullYear();
   }
 }

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <jm-app-root></jm-app-root>
 </body>
 </html>

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,8 +1,8 @@
-import { enableProdMode } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {enableProdMode} from '@angular/core';
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
-import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
+import {AppModule} from './app/app.module';
+import {environment} from './environments/environment';
 
 if (environment.production) {
   enableProdMode();

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -6,7 +6,7 @@ import 'zone.js/dist/sync-test';
 import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/async-test';
 import 'zone.js/dist/fake-async-test';
-import { getTestBed } from '@angular/core/testing';
+import {getTestBed} from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting


### PR DESCRIPTION
Reformat all of our typescript to follow best practices for clean code.

- All selectors prefixed with `jm-` (stands for job monitor, reduces potential collisions with imported or native html tags)
- Lots of alphabetization
- Third party imports separate from internal imports
- Typescript files ordered private properties > public properties > lifecycle methods in lifecycle order > private methods > methods public methods. Alphabetized

Note: These are purely cosmetic changes with the exception of the `jm-` renames. No code was harmed in the making of this PR