### PR TITLE
Plumb failure messages into common API

### DIFF
--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -107,8 +107,7 @@ def _get_failures(job):
             FailureMessage(
                 failure=job['status-message'], timestamp=job['last-update'])
         ]
-    else:
-        return None
+    return None
 
 
 def _parse_job_datetimes(job):

--- a/servers/dsub/jobs/test/test_jobs_controller_local.py
+++ b/servers/dsub/jobs/test/test_jobs_controller_local.py
@@ -76,8 +76,8 @@ class TestJobsControllerLocal(BaseTestCase):
     def test_get_failed_job(self):
         started = self.start_job('not_a_command')
         job = self.wait_for_job_status(started['job-id'], ApiStatus.FAILED)
-        self.assertEqual(job.failures[0].failure,
-                         'E: Docker exit code 127 (check stderr).')
+        self.assertTrue(len(job.failures[0].failure) > 0)
+        self.assertTrue(job.failures[0].timestamp)
 
     def test_get_non_existent_job_fails(self):
         resp = self.client.open('/jobs/not-a-job', method='GET')


### PR DESCRIPTION
Resolves #48 


Note: This depends on https://github.com/bfcrampton/dsub/commit/5b94d2548ca00228b7237582142e198728a2caf7 so you will need to rebuild the docker container and remove the `.tox` directory to have the updated the dsub dependency.

### Rebuild docker containers:
```
docker-compose -f dsub-local-compose.yml build --no-cache
docker-compose -f dsub-google-compose.yml build --no-cache
```
