### PR TITLE
[API] Add securityDefinitions and Unauthorized response

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -310,6 +310,6 @@ securityDefinitions:
     x-google-issuer: "https://accounts.google.com"
     x-google-jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
     scopes:
-      https://www.googleapis.com/auth/cloud-platform: Full access to all resources and services in the specified Cloud Platform project
       https://www.googleapis.com/auth/genomics: Full access to google genomics and pipelines API
-      https://www.googleapis.com/auth/devstorage.read_write: Full access to Google Cloud Storage
+security:
+  google_id_token: []

--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -1,6 +1,6 @@
 import connexion
 from flask import current_app
-from werkzeug.exceptions import BadRequest, Unauthorized
+from werkzeug.exceptions import BadRequest
 from datetime import datetime
 from dateutil.tz import tzlocal
 from dsub.providers import google

--- a/servers/dsub/jobs/swagger/swagger.yaml
+++ b/servers/dsub/jobs/swagger/swagger.yaml
@@ -94,12 +94,8 @@ securityDefinitions:
     authorizationUrl: ""
     flow: "implicit"
     scopes:
-      https://www.googleapis.com/auth/cloud-platform: "Full access to all resources\
-        \ and services in the specified Cloud Platform project"
       https://www.googleapis.com/auth/genomics: "Full access to google genomics and\
         \ pipelines API"
-      https://www.googleapis.com/auth/devstorage.read_write: "Full access to Google\
-        \ Cloud Storage"
     x-google-issuer: "https://accounts.google.com"
     x-google-jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
 definitions:


### PR DESCRIPTION
This is needed for dsub/dstat to access jobs' status for a given user's own Google Cloud projects. 

I'm not sure if the exact same auth flow will be needed for cromwell (i.e. a Google account auth), but this field could be populated with a different token if that is the case.