### PR TITLE
Implement cromwell abort jobs endpoint

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -1,7 +1,7 @@
 import requests
-import connexion
 from requests.auth import HTTPBasicAuth
 from flask import current_app
+from werkzeug.exceptions import NotFound
 from datetime import datetime
 
 from jobs.models.query_jobs_result import QueryJobsResult
@@ -18,7 +18,11 @@ def abort_job(id):
 
     :rtype: None
     """
-    return 'abort job'
+    url = '{cromwell_url}/{id}/abort'.format(
+        cromwell_url=_get_base_url(), id=id)
+    response = requests.post(url, auth=_get_user_auth())
+    if response.status_code == NotFound.code:
+        raise NotFound(response.json()['message'])
 
 
 def get_job(id):

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -15,15 +15,55 @@ from jobs.controllers import jobs_controller
 class TestJobsController(BaseTestCase):
     """ JobsController integration test stubs """
 
-    def test_abort_job(self):
+    def setUp(self):
+        self.base_url = 'https://test-cromwell.org'
+        self.app.config.update({
+            'cromwell_url': self.base_url,
+            'cromwell_user': 'user',
+            'cromwell_password': 'password'
+        })
+
+    @requests_mock.mock()
+    def test_abort_job(self, mock_request):
         """
         Test case for abort_job
 
         Abort a job by ID
         """
+        workflow_id = 'id'
+
+        def _request_callback(request, context):
+            context.status_code = 200
+
+        abort_url = self.base_url + '/{id}/abort'.format(id=workflow_id)
+        mock_request.post(abort_url, json=_request_callback)
+
         response = self.client.open(
-            '/jobs/{id}/abort'.format(id='id_example'), method='POST')
+            '/jobs/{id}/abort'.format(id=workflow_id), method='POST')
         self.assertStatus(response, 200)
+
+    @requests_mock.mock()
+    def test_abort_job_not_found(self, mock_request):
+        """Test that aborting a job that is not running returns a 404 response."""
+        workflow_id = 'id'
+
+        def _request_callback(request, context):
+            context.status_code = 404
+            return {
+                "status":
+                "error",
+                "message":
+                "Couldn't abort {} because no workflow with that ID is in progress".
+                format(workflow_id)
+            }
+
+        # mock cromwell response
+        abort_url = self.base_url + '/{id}/abort'.format(id=workflow_id)
+        mock_request.post(abort_url, json=_request_callback)
+
+        response = self.client.open(
+            '/jobs/{id}/abort'.format(id=workflow_id), method='POST')
+        self.assertStatus(response, 404)
 
     def test_get_job(self):
         """
@@ -42,19 +82,13 @@ class TestJobsController(BaseTestCase):
 
         Query jobs by various filter criteria. Returned jobs are ordered from newest to oldest submission time.
         """
-        base_url = 'https://test-cromwell.org'
-        self.app.config.update({
-            'cromwell_url': base_url,
-            'cromwell_user': 'user',
-            'cromwell_password': 'password'
-        })
 
         def _request_callback(request, context):
             context.status_code = 200
             return {'results': []}
 
         # mock cromwell response
-        query_url = base_url + '/query'
+        query_url = self.base_url + '/query'
         mock_request.post(query_url, json=_request_callback)
 
         query = QueryJobsRequest()


### PR DESCRIPTION
Implement `/jobs/{id}/abort` endpoint in cromwell translation API 