### PR TITLE
Add "Done" as a job status

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -172,6 +172,7 @@ definitions:
       - Failed
       - Succeeded
       - Aborted
+      - Done
   TaskMetadata:
     description: Task level metadata
     properties:

--- a/servers/cromwell/jobs/swagger/swagger.yaml
+++ b/servers/cromwell/jobs/swagger/swagger.yaml
@@ -190,6 +190,7 @@ definitions:
     - "Failed"
     - "Succeeded"
     - "Aborted"
+    - "Done"
   TaskMetadata:
     properties:
       inputs:

--- a/servers/dsub/jobs/swagger/swagger.yaml
+++ b/servers/dsub/jobs/swagger/swagger.yaml
@@ -190,6 +190,7 @@ definitions:
     - "Failed"
     - "Succeeded"
     - "Aborted"
+    - "Done"
   TaskMetadata:
     properties:
       inputs:

--- a/ui/src/app/job-details/panels/panels.component.ts
+++ b/ui/src/app/job-details/panels/panels.component.ts
@@ -31,7 +31,7 @@ export class JobPanelsComponent implements OnChanges {
       this.tasks = this.job.tasks;
       this.numTasks = this.tasks.length;
       for (let task of this.tasks) {
-        if (task.executionStatus == JobStatus[JobStatus.Succeeded]) {
+        if (task.executionStatus == JobStatus[JobStatus.Succeeded] || task.executionStatus == JobStatus[JobStatus.Done]) {
           this.numCompletedTasks++;
         }
       }

--- a/ui/src/app/shared/common.ts
+++ b/ui/src/app/shared/common.ts
@@ -6,6 +6,7 @@ export enum JobStatusImage {
   Aborting = <any> 'https://www.gstatic.com/images/icons/material/system/1x/report_problem_grey600_24dp.png',
   Failed = <any> 'https://www.gstatic.com/images/icons/material/system/1x/close_grey600_24dp.png',
   Succeeded = <any> 'https://www.gstatic.com/images/icons/material/system/1x/done_grey600_24dp.png',
+  Done = <any> 'https://www.gstatic.com/images/icons/material/system/1x/done_grey600_24dp.png',
   Aborted = <any> 'https://www.gstatic.com/images/icons/material/system/1x/report_problem_grey600_24dp.png'
 }
 

--- a/ui/src/app/shared/model/JobStatus.ts
+++ b/ui/src/app/shared/model/JobStatus.ts
@@ -18,5 +18,6 @@ export enum JobStatus {
     Aborting = <any> 'Aborting',
     Failed = <any> 'Failed',
     Succeeded = <any> 'Succeeded',
-    Aborted = <any> 'Aborted'
+    Aborted = <any> 'Aborted',
+    Done = <any> 'Done'
 }


### PR DESCRIPTION
- Add "Done" to the list of job statuses and job icons, since completed cromwell tasks have the executionStatus "Done"
- When calculating the number of completed tasks, check for tasks that have the status "Succeeded" or "Done" 

Here's an example job detail page that shows these changes: 

<img width="1262" alt="screen shot 2017-11-07 at 6 32 40 pm" src="https://user-images.githubusercontent.com/6414394/32523702-7cadf4da-c3ea-11e7-973f-f84d35369323.png">
