### PR TITLE
[API] Allow dashses in QueryJobsRequest name

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -264,7 +264,7 @@ definitions:
           matches to each of these labels.
       name:
         type: string
-        pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+        pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
         description: >
           Returns only jobs with the specified name.
       pageSize:

--- a/servers/cromwell/jobs/models/query_jobs_request.py
+++ b/servers/cromwell/jobs/models/query_jobs_request.py
@@ -190,8 +190,8 @@ class QueryJobsRequest(Model):
         :param name: The name of this QueryJobsRequest.
         :type name: str
         """
-        if name is not None and not re.search('^[a-zA-Z][a-zA-Z0-9_]*$', name):
-            raise ValueError("Invalid value for `name`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9_]*$/`")
+        if name is not None and not re.search('^[a-zA-Z][a-zA-Z0-9_-]*$', name):
+            raise ValueError("Invalid value for `name`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9_-]*$/`")
 
         self._name = name
 

--- a/servers/cromwell/jobs/swagger/swagger.yaml
+++ b/servers/cromwell/jobs/swagger/swagger.yaml
@@ -280,8 +280,8 @@ definitions:
       name:
         type: "string"
         description: "Returns only jobs with the specified name.\n"
-        pattern: "^[a-zA-Z][a-zA-Z0-9_]*$"
-        x-regex: "^[a-zA-Z][a-zA-Z0-9_]*$"
+        pattern: "^[a-zA-Z][a-zA-Z0-9_-]*$"
+        x-regex: "^[a-zA-Z][a-zA-Z0-9_-]*$"
         x-modifiers: []
       pageSize:
         type: "integer"

--- a/servers/dsub/jobs/models/query_jobs_request.py
+++ b/servers/dsub/jobs/models/query_jobs_request.py
@@ -190,8 +190,8 @@ class QueryJobsRequest(Model):
         :param name: The name of this QueryJobsRequest.
         :type name: str
         """
-        if name is not None and not re.search('^[a-zA-Z][a-zA-Z0-9_]*$', name):
-            raise ValueError("Invalid value for `name`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9_]*$/`")
+        if name is not None and not re.search('^[a-zA-Z][a-zA-Z0-9_-]*$', name):
+            raise ValueError("Invalid value for `name`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9_-]*$/`")
 
         self._name = name
 

--- a/servers/dsub/jobs/swagger/swagger.yaml
+++ b/servers/dsub/jobs/swagger/swagger.yaml
@@ -280,8 +280,8 @@ definitions:
       name:
         type: "string"
         description: "Returns only jobs with the specified name.\n"
-        pattern: "^[a-zA-Z][a-zA-Z0-9_]*$"
-        x-regex: "^[a-zA-Z][a-zA-Z0-9_]*$"
+        pattern: "^[a-zA-Z][a-zA-Z0-9_-]*$"
+        x-regex: "^[a-zA-Z][a-zA-Z0-9_-]*$"
         x-modifiers: []
       pageSize:
         type: "integer"


### PR DESCRIPTION
dsub job names (with the google provider) are always stored with dashes instead of underscores 