### PR TITLE
[dsub] Fix oauth2client version conflict

### DIFF
--- a/servers/dsub/requirements-to-freeze.txt
+++ b/servers/dsub/requirements-to-freeze.txt
@@ -1,4 +1,5 @@
 connexion == 1.1.13
+google-api-python-client == 1.5.5
 gunicorn == 19.7.1
-oauth2client == 4.1.2
+oauth2client == 3.0.0
 dsub == 0.1.1

--- a/servers/dsub/requirements.txt
+++ b/servers/dsub/requirements.txt
@@ -1,5 +1,4 @@
-argparse==1.2.1
-certifi==2017.7.27.1
+certifi==2017.11.5
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
@@ -7,7 +6,7 @@ connexion==1.1.13
 dsub==0.1.1
 Flask==0.12.2
 functools32==3.2.3-2
-google-api-python-client==1.6.4
+google-api-python-client==1.5.5
 gunicorn==19.7.1
 httplib2==0.10.3
 idna==2.6
@@ -16,7 +15,7 @@ itsdangerous==0.24
 Jinja2==2.9.6
 jsonschema==2.6.0
 MarkupSafe==1.0
-oauth2client==4.1.2
+oauth2client==3.0.0
 parameterized==0.6.1
 pathlib==1.0.1
 pyasn1==0.3.7


### PR DESCRIPTION
When using oauth2client >= 4.0.0 dsub throws the following error:
```
file_cache is unavailable when using oauth2client >= 4.0.0
```

Pin `google-api-python-client` to the same version as `dsub` and `oauth2client` to the newest compatible version (`3.0.0`).