### PR TITLE
[dsub] Add required resources parameter for LocalJobProvider

### DIFF
--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -2,6 +2,7 @@ import connexion
 from datetime import datetime
 from dateutil.tz import tzlocal
 from dsub.providers import google, local, stub
+from dsub.lib import resources
 from flask import current_app, request
 from oauth2client.client import AccessTokenCredentials, AccessTokenCredentialsError
 from werkzeug.exceptions import BadRequest, Unauthorized, NotImplemented
@@ -142,7 +143,9 @@ def _get_provider(parent_id=None, auth_token=None):
             'The Local provider does not support the `{}` field .'.format(
                 'authToken' if auth_token else 'parentId'))
     elif _provider_type() == dsub_client.ProviderType.LOCAL:
-        return local.LocalJobProvider()
+        # TODO(https://github.com/googlegenomics/dsub/issues/93): Remove
+        # resources parameter and import
+        return local.LocalJobProvider(resources)
     elif _provider_type() == dsub_client.ProviderType.STUB:
         return stub.StubJobProvider()
 

--- a/servers/dsub/jobs/test/test_jobs_controller_local.py
+++ b/servers/dsub/jobs/test/test_jobs_controller_local.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from dsub.providers import local
+from dsub.lib import resources
 import operator
 import os
 import shutil
@@ -23,7 +24,9 @@ class TestJobsControllerLocal(BaseTestCases.JobsControllerTestCase):
     def setUpClass(cls):
         super(TestJobsControllerLocal, cls).setUpClass()
         cls.testing_bucket = 'gs://bvdp-jmui-testing/local'
-        cls.provider = local.LocalJobProvider()
+        # TODO(https://github.com/googlegenomics/dsub/issues/93): Remove
+        # resources parameter and import
+        cls.provider = local.LocalJobProvider(resources)
 
     def setUp(self):
         self.dsub_local_dir = tempfile.mkdtemp()


### PR DESCRIPTION
I'm not sure how I missed this before, but a new paramter was added to the `LocalJobProvider` [here](https://github.com/googlegenomics/dsub/commit/deae452b1934ae8d4d5634f0341510cc130d9cd0). 

I think this should have a default argument and be unnecessary, it seems unnecessary to import a dsub module just to pass it back to a dsub initializer.