### PR TITLE
Simplify running job manager with cromwell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 *.settings
 client_secrets.json
 swagger-codegen-cli.jar
+config.json
 
 .venv
 venv/

--- a/common-compose.yml
+++ b/common-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   ui:
     build:
@@ -35,7 +35,7 @@ services:
     environment:
       - PATH_PREFIX=/api/v1
       - CROMWELL_CREDENTIALS=/etc/job-manager/config.json
-      - CROMWELL_URL=https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1
+      - CROMWELL_URL=${CROMWELL_URL:-https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1}
     volumes:
       - ./servers/cromwell/jobs:/app/jobs
       - /private/etc/job-manager:/etc/job-manager

--- a/common-compose.yml
+++ b/common-compose.yml
@@ -34,11 +34,10 @@ services:
     command: ["-b", ":8190"]
     environment:
       - PATH_PREFIX=/api/v1
-      - CROMWELL_CREDENTIALS=/etc/job-manager/config.json
+      - CROMWELL_CREDENTIALS=/app/jobs/config.json
       - CROMWELL_URL=${CROMWELL_URL:-https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1}
     volumes:
       - ./servers/cromwell/jobs:/app/jobs
-      - /private/etc/job-manager:/etc/job-manager
     ports:
       - 8190:8190
   jobs-proxy:

--- a/cromwell-compose.yml
+++ b/cromwell-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   ui:
     extends:

--- a/dsub-google-compose.yml
+++ b/dsub-google-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   ui:
     extends:

--- a/dsub-local-compose.yml
+++ b/dsub-local-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   ui:
     extends:

--- a/servers/cromwell/README.md
+++ b/servers/cromwell/README.md
@@ -4,8 +4,11 @@ Thin shim around [`cromwell`](https://github.com/broadinstitute/cromwell).
 
 ## Development
 For cromwell setup see the Cromwell README:
-1. Create a local job-manager dir: `mkdir /private/etc/job-manager/`
-1. Then add a config.json file with the Cromwell username and password:
+1. Set the `CROMWELL_URL` environment variable to specify which cromwell instance to use. Job Manager pulls workflow data from `https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1` by default:
+```
+export CROMWELL_URL=https://cromwell.test-cromwell.broadinstitute.org/api/workflows/v1
+```
+2. Add a file named `config.json` to `job-manager/servers/cromwell/jobs` that contains the username and password for the specified cromwell instance:
 ```
 {
   "cromwell_user" : "USERNAME",


### PR DESCRIPTION
Simplify running the job manager with cromwell as a backend by 
1. Making it easier to override the default `CROMWELL_URL` defined in `common-compose.yml`
2. Moving the location of the cromwell `config.json` to `/servers/cromwell/jobs` to remove the extra step of having to create a folder in your root directory (note: anyone who is currently running the job manager locally for cromwell will need to move `/private/etc/job-manager/config.json` to `/servers/cromwell/jobs`