### PR TITLE
[dsub] Fix support for querying by job start

### DIFF
--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -118,6 +118,8 @@ def query_jobs(body):
         query.page_size = _DEFAULT_PAGE_SIZE
     elif query.page_size < 0:
         raise BadRequest("The pageSize query parameter must be non-negative.")
+    if query.start:
+        query.start = query.start.replace(tzinfo=tzlocal())
     query.page_size = min(query.page_size, _MAX_PAGE_SIZE)
     provider = providers.get_provider(_provider_type(), query.parent_id,
                                       _auth_token())

--- a/servers/dsub/jobs/controllers/utils/query_parameters.py
+++ b/servers/dsub/jobs/controllers/utils/query_parameters.py
@@ -1,3 +1,5 @@
+import datetime
+from dateutil.tz import tzutc
 from dsub.lib import param_util
 
 import job_statuses
@@ -13,11 +15,13 @@ def api_to_dsub(query):
             dict: Key value pairs of query parameters, formatted for dstat
     """
 
-    dstat_params = {
-        'create_time': query.start,
-        'end_time': query.end,
-        'job_names': [query.name] if query.name else None,
-    }
+    dstat_params = {}
+
+    epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=tzutc())
+    dstat_params['create_time'] = int(
+        (query.start - epoch).total_seconds()) if query.start else None
+
+    dstat_params['job_names'] = {query.name} if query.name else None
 
     dstat_params['statuses'] = {
         job_statuses.api_to_dsub(s)

--- a/servers/dsub/jobs/test/base_test_cases.py
+++ b/servers/dsub/jobs/test/base_test_cases.py
@@ -333,9 +333,11 @@ class BaseTestCases:
             fourth_job = self.start_job('echo FOURTH_JOB', name='job4')
 
             self.assert_query_matches(
-                QueryJobsRequest(start=first_time), [first_job, second_job, third_job, fourth_job])
+                QueryJobsRequest(start=first_time),
+                [first_job, second_job, third_job, fourth_job])
             self.assert_query_matches(
-                QueryJobsRequest(start=second_time), [second_job, third_job, fourth_job])
+                QueryJobsRequest(start=second_time),
+                [second_job, third_job, fourth_job])
             self.assert_query_matches(
                 QueryJobsRequest(start=third_time), [third_job, fourth_job])
             self.assert_query_matches(

--- a/servers/dsub/jobs/test/base_test_cases.py
+++ b/servers/dsub/jobs/test/base_test_cases.py
@@ -1,4 +1,5 @@
 import connexion
+import datetime
 from dsub.commands import dsub
 from dsub.lib import job_util, param_util
 import flask
@@ -317,3 +318,25 @@ class BaseTestCases:
                 QueryJobsRequest(labels={
                     'overlap_key': 'overlap_value'
                 }), [label_job, other_label_job])
+
+        def test_query_jobs_by_start(self):
+            first_time = datetime.datetime.now()
+            first_job = self.start_job('echo FIRST_JOB', name='job1')
+            time.sleep(1)
+            second_time = datetime.datetime.now()
+            second_job = self.start_job('echo SECOND_JOB', name='job2')
+            time.sleep(1)
+            third_time = datetime.datetime.now()
+            third_job = self.start_job('echo THIRD_JOB', name='job3')
+            time.sleep(1)
+            fourth_time = datetime.datetime.now()
+            fourth_job = self.start_job('echo FOURTH_JOB', name='job4')
+
+            self.assert_query_matches(
+                QueryJobsRequest(start=first_time), [first_job, second_job, third_job, fourth_job])
+            self.assert_query_matches(
+                QueryJobsRequest(start=second_time), [second_job, third_job, fourth_job])
+            self.assert_query_matches(
+                QueryJobsRequest(start=third_time), [third_job, fourth_job])
+            self.assert_query_matches(
+                QueryJobsRequest(start=fourth_time), [fourth_job])


### PR DESCRIPTION
`dstat` takes in create_time as seconds from epoch which it directly passes to the pipelines API. We've been passing in a datetime which doesn't work.