### PR TITLE
Update page_tokens to support created_before + offset_id tokens

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -163,10 +163,8 @@ def query_jobs(body):
     """
     query = QueryJobsRequest.from_dict(body)
 
-    page_size = query.page_size
-    if not page_size:
-        page_size = _DEFAULT_PAGE_SIZE
-    offset = page_tokens.decode(query.page_token)
+    page_size = query.page_size or _DEFAULT_PAGE_SIZE
+    offset = page_tokens.decode_offset(query.page_token) or 0
     page = page_from_offset(offset, page_size)
     params_for_cromwell = cromwell_query_params(query, page, page_size)
 
@@ -179,14 +177,12 @@ def query_jobs(body):
     results.reverse()
 
     next_offset = offset + page_size
-    next_page_token = page_tokens.encode(next_offset)
+    next_page_token = page_tokens.encode_offset(next_offset)
 
     return QueryJobsResponse(results=results, next_page_token=next_page_token)
 
 
 def page_from_offset(offset, page_size):
-    if not page_size:
-        page_size = _DEFAULT_PAGE_SIZE
     return 1 + offset / page_size
 
 

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -589,8 +589,6 @@ class TestJobsController(BaseTestCase):
 
     def test_page_from_offset(self):
         self.assertEqual(
-            jobs_controller.page_from_offset(offset=0, page_size=None), 1)
-        self.assertEqual(
             jobs_controller.page_from_offset(offset=0, page_size=1), 1)
         self.assertEqual(
             jobs_controller.page_from_offset(offset=1, page_size=1), 2)

--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -131,7 +131,7 @@ def query_jobs(body):
 
     # Request one extra job to confirm whether there's more data to return
     # in a subsequent page.
-    offset = page_tokens.decode(query.page_token)
+    offset = page_tokens.decode_offset(query.page_token) or 0
     max_tasks = offset + query.page_size + 1
 
     jobs = []
@@ -162,7 +162,7 @@ def query_jobs(body):
     next_offset = offset + query.page_size
     if len(jobs) > next_offset:
         jobs = jobs[offset:next_offset]
-        next_page_token = page_tokens.encode(next_offset)
+        next_page_token = page_tokens.encode_offset(next_offset)
     elif len(jobs) == next_offset:
         jobs = jobs[offset:]
 

--- a/servers/jm_utils/jm_utils/page_tokens.py
+++ b/servers/jm_utils/jm_utils/page_tokens.py
@@ -1,44 +1,133 @@
 import base64
+import datetime
 import json
 import numbers
 
 
-def encode(offset):
-    """Encode the jobs pagination token.
+# We implement the pagination token via base64-encoded JSON s.t. tokens are
+# opaque to clients and enable us to make backwards compatible changes to our
+# pagination implementation. Base64+JSON are used specifically as they are
+# easily portable across language.
 
-    We implement the pagination token via base64-encoded JSON s.t. tokens are
-    opaque to clients and enable us to make backwards compatible changes to our
-    pagination implementation. Base64+JSON are used specifically as they are
-    easily portable across language.
+
+def _encode(dictionary):
+    """Encodes any arbitrary dictionary into a jobs pagination token.
 
     Args:
-      offset: (int) index into the overall list of jobs matching the query
+        dictionary: (dict) Dictionary to basee64-encode
+    
     Returns:
-      (string) encoded page token representing a page of jobs
+        (string) encoded page token representing a page of jobs
     """
-    s = json.dumps({
-        'of': offset,
-    })
     # Strip ugly base64 padding.
-    return base64.urlsafe_b64encode(s).rstrip('=')
+    return base64.urlsafe_b64encode(json.dumps(dictionary)).rstrip('=')
 
-
-def decode(token):
-    """Decode the jobs pagination token.
+def _decode(token):
+    """Decodes the jobs pagination token.
 
     Args:
-      token: (string) base64 encoded JSON pagination token
+        token: (string) Base64 encoded JSON pagination token
 
     Returns:
-      (number) the pagination offset, defaults to 0 if token is None
+        (dict) The token dictionary representing a page of jobs.
     """
     if not token:
-        return 0
+        return None
     # Pad the token out to be divisible by 4.
     padded_token = token + '=' * (4 - (len(token) % 4))
     decoded_token = base64.urlsafe_b64decode(padded_token)
     token_dict = json.loads(decoded_token)
+    if not token_dict or not isinstance(token_dict, dict):
+        raise ValueError('Invalid pagination token: {}').format(token_dict)
+    return token_dict
+
+
+def encode_offset(offset):
+    """Encodes an offset integer into a jobs pagination token.
+    
+    Args:
+      offset: (int) index into the overall list of jobs matching the query
+    
+    Returns:
+      (string) encoded page token representing a page of jobs
+    """
+    if offset == None:
+        return None
+
+    if not isinstance(offset, numbers.Number) or offset <= 0:
+        raise ValueError('Invalid offset must integer > 0: {}'.format(offset))
+    return _encode({'of': offset})
+
+
+def encode_created_before(created_before, offset_id=None):
+    """Encodes a created_before and optional offset job ID into a jobs pagination token.
+    
+    Args:
+      created_before: (datetime) The create-time of the first job to include in the associated page.
+      offset_id: (str) The unique job-id of the first job to include in the associated page. Needed
+        only if the previous page ends with a job containing the same create-time.
+    
+    Returns:
+      (string) encoded page token representing a page of jobs.
+    """
+    if not created_before:
+        return None
+
+    if not isinstance(created_before, datetime.datetime):
+        raise ValueError('Invalid create time must be datetime: {}'.format(created_before))
+    if offset_id and not isinstance(offset_id, basestring):
+        raise ValueError('Invalid offset id must be string: {}'.format(offset_id))
+
+    epoch = datetime.datetime.utcfromtimestamp(0)
+    seconds_epoch = int((created_before - epoch).total_seconds())
+    token_dict = {'created-before': seconds_epoch}
+    if offset_id:
+        token_dict['offset-id'] = offset_id
+    return _encode(token_dict)
+
+
+def decode_offset(token):
+    """Decodes the jobs offset-pagination token.
+
+    Args:
+        token: (string) base64 encoded JSON offset-pagination token
+
+    Returns:
+        (number) the pagination offset, defaults to 0 if token is None
+    """
+    token_dict = _decode(token)
+    if not token_dict:
+        return None
+
     offset = token_dict.get('of')
     if not offset or not isinstance(offset, numbers.Number) or offset <= 0:
-        raise ValueError('Invalid token JSON {}'.format(token_dict))
+        raise ValueError('Invalid offset token JSON: {}'.format(token_dict))
     return offset
+
+
+def decode_created_before(token):
+    """Decode a created_before and optional offset job ID pagination token.
+
+    Args:
+        token: (string) base64 encoded JSON offset-pagination token
+
+    Returns:
+        (datetime) The create-time of the first job to include in this page.
+        (str) The unique job-id of the first job to include in this page.
+    """
+    token_dict = _decode(token)
+    if not token_dict:
+        return None
+
+    created_before = token_dict.get('created-before')
+    offset_id = token_dict.get('offset-id')
+
+    if created_before and isinstance(created_before, numbers.Number):
+        created_before = datetime.datetime.utcfromtimestamp(created_before)
+    else:
+        raise ValueError('Invalid created before in token JSON: {}'.format(token_dict))
+
+    if offset_id and not isinstance(offset_id, basestring):
+        raise ValueError('Invalid offset ID in token JSON: {}'.format(token_dict))
+
+    return created_before, offset_id

--- a/servers/jm_utils/jm_utils/page_tokens.py
+++ b/servers/jm_utils/jm_utils/page_tokens.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import numbers
 
-
 # We implement the pagination token via base64-encoded JSON s.t. tokens are
 # opaque to clients and enable us to make backwards compatible changes to our
 # pagination implementation. Base64+JSON are used specifically as they are
@@ -21,6 +20,7 @@ def _encode(dictionary):
     """
     # Strip ugly base64 padding.
     return base64.urlsafe_b64encode(json.dumps(dictionary)).rstrip('=')
+
 
 def _decode(token):
     """Decodes the jobs pagination token.
@@ -74,9 +74,11 @@ def encode_created_before(created_before, offset_id=None):
         return None
 
     if not isinstance(created_before, datetime.datetime):
-        raise ValueError('Invalid create time must be datetime: {}'.format(created_before))
+        raise ValueError(
+            'Invalid create time must be datetime: {}'.format(created_before))
     if offset_id and not isinstance(offset_id, basestring):
-        raise ValueError('Invalid offset id must be string: {}'.format(offset_id))
+        raise ValueError(
+            'Invalid offset id must be string: {}'.format(offset_id))
 
     epoch = datetime.datetime.utcfromtimestamp(0)
     seconds_epoch = int((created_before - epoch).total_seconds())
@@ -125,9 +127,11 @@ def decode_created_before(token):
     if created_before and isinstance(created_before, numbers.Number):
         created_before = datetime.datetime.utcfromtimestamp(created_before)
     else:
-        raise ValueError('Invalid created before in token JSON: {}'.format(token_dict))
+        raise ValueError(
+            'Invalid created before in token JSON: {}'.format(token_dict))
 
     if offset_id and not isinstance(offset_id, basestring):
-        raise ValueError('Invalid offset ID in token JSON: {}'.format(token_dict))
+        raise ValueError(
+            'Invalid offset ID in token JSON: {}'.format(token_dict))
 
     return created_before, offset_id

--- a/servers/jm_utils/jm_utils/test/test_page_tokens.py
+++ b/servers/jm_utils/jm_utils/test/test_page_tokens.py
@@ -50,12 +50,12 @@ class TestJmUtils(unittest.TestCase):
             context.exception))
 
     def test_decode_created_before_invalid(self):
-        encoded = page_tokens._encode({'created-before': 'not-a-date'})
+        encoded = page_tokens._encode({'cb': 'not-a-date'})
         with self.assertRaises(ValueError) as context:
             page_tokens.decode_created_before(encoded)
         self.assertIn('Invalid created before in token JSON',
                       str(context.exception))
-        encoded = page_tokens._encode({'created-before': 10, 'offset-id': 123})
+        encoded = page_tokens._encode({'cb': 10, 'oi': 123})
         with self.assertRaises(ValueError) as context:
             page_tokens.decode_created_before(encoded)
         self.assertIn('Invalid offset ID in token JSON', str(

--- a/servers/jm_utils/jm_utils/test/test_page_tokens.py
+++ b/servers/jm_utils/jm_utils/test/test_page_tokens.py
@@ -19,7 +19,8 @@ class TestJmUtils(unittest.TestCase):
     def test_encode_offset_zero(self):
         with self.assertRaises(ValueError) as context:
             page_tokens.encode_offset(0)
-        self.assertIn('Invalid offset must integer > 0', str(context.exception))
+        self.assertIn('Invalid offset must integer > 0', str(
+            context.exception))
 
     def test_decode_offset_zero(self):
         encoded = page_tokens._encode({'of': 0})
@@ -33,27 +34,32 @@ class TestJmUtils(unittest.TestCase):
     def test_encode_decode_created_before(self):
         now = datetime.datetime.now().replace(microsecond=0)
         encoded = page_tokens.encode_created_before(now, 'offset-id')
-        decoded_create_time, decoded_offset_id = page_tokens.decode_created_before(encoded)
+        decoded_create_time, decoded_offset_id = page_tokens.decode_created_before(
+            encoded)
         self.assertEqual(decoded_create_time, now)
         self.assertEqual(decoded_offset_id, 'offset-id')
 
     def test_encode_created_before_invalid(self):
         with self.assertRaises(ValueError) as context:
             page_tokens.encode_created_before('not-a-date')
-        self.assertIn('Invalid create time must be datetime', str(context.exception))
+        self.assertIn('Invalid create time must be datetime',
+                      str(context.exception))
         with self.assertRaises(ValueError) as context:
             page_tokens.encode_created_before(datetime.datetime.now(), 123)
-        self.assertIn('Invalid offset id must be string', str(context.exception))
+        self.assertIn('Invalid offset id must be string', str(
+            context.exception))
 
     def test_decode_created_before_invalid(self):
         encoded = page_tokens._encode({'created-before': 'not-a-date'})
         with self.assertRaises(ValueError) as context:
             page_tokens.decode_created_before(encoded)
-        self.assertIn('Invalid created before in token JSON', str(context.exception))
-        encoded = page_tokens._encode({'created-before': 10, 'offset-id' : 123})
+        self.assertIn('Invalid created before in token JSON',
+                      str(context.exception))
+        encoded = page_tokens._encode({'created-before': 10, 'offset-id': 123})
         with self.assertRaises(ValueError) as context:
             page_tokens.decode_created_before(encoded)
-        self.assertIn('Invalid offset ID in token JSON', str(context.exception))
+        self.assertIn('Invalid offset ID in token JSON', str(
+            context.exception))
 
     def test_decode_created_before_none(self):
         self.assertEqual(page_tokens.decode_created_before(None), None)

--- a/servers/jm_utils/jm_utils/test/test_page_tokens.py
+++ b/servers/jm_utils/jm_utils/test/test_page_tokens.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import datetime
 import unittest
 
 from .. import page_tokens
@@ -10,22 +11,52 @@ from .. import page_tokens
 class TestJmUtils(unittest.TestCase):
     """ jm_utils unit tests """
 
-    def setUp(self):
-        self.base_url = 'https://test-cromwell.org'
-
-    def test_encode_decode(self):
-        encoded = page_tokens.encode(12)
-        decoded = page_tokens.decode(encoded)
+    def test_encode_decode_offset(self):
+        encoded = page_tokens.encode_offset(12)
+        decoded = page_tokens.decode_offset(encoded)
         self.assertEqual(decoded, 12)
 
-    def test_encode_decode_zero(self):
-        encoded = page_tokens.encode(0)
+    def test_encode_offset_zero(self):
         with self.assertRaises(ValueError) as context:
-            page_tokens.decode(encoded)
-        self.assertIn('Invalid token', str(context.exception))
+            page_tokens.encode_offset(0)
+        self.assertIn('Invalid offset must integer > 0', str(context.exception))
 
-    def test_decode_none(self):
-        self.assertEqual(page_tokens.decode(None), 0)
+    def test_decode_offset_zero(self):
+        encoded = page_tokens._encode({'of': 0})
+        with self.assertRaises(ValueError) as context:
+            page_tokens.decode_offset(encoded)
+        self.assertIn('Invalid offset token JSON', str(context.exception))
+
+    def test_decode_offset_none(self):
+        self.assertEqual(page_tokens.decode_offset(None), None)
+
+    def test_encode_decode_created_before(self):
+        now = datetime.datetime.now().replace(microsecond=0)
+        encoded = page_tokens.encode_created_before(now, 'offset-id')
+        decoded_create_time, decoded_offset_id = page_tokens.decode_created_before(encoded)
+        self.assertEqual(decoded_create_time, now)
+        self.assertEqual(decoded_offset_id, 'offset-id')
+
+    def test_encode_created_before_invalid(self):
+        with self.assertRaises(ValueError) as context:
+            page_tokens.encode_created_before('not-a-date')
+        self.assertIn('Invalid create time must be datetime', str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            page_tokens.encode_created_before(datetime.datetime.now(), 123)
+        self.assertIn('Invalid offset id must be string', str(context.exception))
+
+    def test_decode_created_before_invalid(self):
+        encoded = page_tokens._encode({'created-before': 'not-a-date'})
+        with self.assertRaises(ValueError) as context:
+            page_tokens.decode_created_before(encoded)
+        self.assertIn('Invalid created before in token JSON', str(context.exception))
+        encoded = page_tokens._encode({'created-before': 10, 'offset-id' : 123})
+        with self.assertRaises(ValueError) as context:
+            page_tokens.decode_created_before(encoded)
+        self.assertIn('Invalid offset ID in token JSON', str(context.exception))
+
+    def test_decode_created_before_none(self):
+        self.assertEqual(page_tokens.decode_created_before(None), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a prerequisite for implementing the fixed `dsub` pagination strategy which is based upon querying the Pipelines API with a CreatedBefore parameter.

The only alteration to the behavior for cromwell is the change in `encode` and `decode` method names, and that `page_tokens` returns `None` rather than `0` when trying to decode a `None`. I updated cromwell's `jobs_controller` to handle that. 

I also removed a duplication of:
```
if not page_size:
    page_size = _DEFAULT_PAGE_SIZE
```
in `page_from_offset`. It seems redundant to check that twice rather than do it at right away and know it is present from there forth. There was an associated test that `page_from_offset` can handle `None` which I removed.