### PR TITLE
Don't mutate primaryColumns; teardown table

### DIFF
--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -1,5 +1,6 @@
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Subject} from 'rxjs/Subject';
+import {Subscription} from 'rxjs/Subscription';
 import {
   Component,
   ElementRef,
@@ -43,7 +44,7 @@ export class JobsTableComponent implements OnInit {
   @Input() jobs: BehaviorSubject<JobListView>;
   @Output() onPage = new EventEmitter<PageEvent>();
 
-
+  private pageSubscription: Subscription;
   private mouseoverJob: QueryJobsResult;
 
   public additionalColumns: string[] = [];
@@ -52,7 +53,7 @@ export class JobsTableComponent implements OnInit {
 
   dataSource: JobsDataSource | null;
   // TODO(alanhwang): Allow these columns to be configured by the user
-  displayedColumns = primaryColumns;
+  displayedColumns = primaryColumns.slice();
 
   @ViewChild(MdPaginator) paginator: MdPaginator;
 
@@ -78,7 +79,12 @@ export class JobsTableComponent implements OnInit {
     for (let column of this.additionalColumns) {
       this.displayedColumns.push(column);
     }
-    this.paginator.page.subscribe((e) => this.onPage.emit(e));
+    this.pageSubscription =
+      this.paginator.page.subscribe((e) => this.onPage.emit(e));
+  }
+
+  ngOnDestroy() {
+    this.pageSubscription.unsubscribe();
   }
 
   private onJobsChanged(): void {

--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output,
   ViewChild,
@@ -40,7 +41,7 @@ import {environment} from '../../../environments/environment';
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.css'],
 })
-export class JobsTableComponent implements OnInit {
+export class JobsTableComponent implements OnInit, OnDestroy {
   @Input() jobs: BehaviorSubject<JobListView>;
   @Output() onPage = new EventEmitter<PageEvent>();
 


### PR DESCRIPTION
Previously, loading the table view multiple times would result in user-id (for dsub) being repeatedly appended to the table view multiple times.