### PR TITLE
[dsub] Fix abort job test for google and local providers

### DIFF
--- a/servers/dsub/jobs/test/test_jobs_controller_google.py
+++ b/servers/dsub/jobs/test/test_jobs_controller_google.py
@@ -21,7 +21,8 @@ class TestJobsControllerGoogle(BaseTestCases.JobsControllerTestCase):
         cls.testing_project = 'bvdp-jmui-testing'
         cls.provider = google.GoogleJobProvider(False, False,
                                                 cls.testing_project)
-        cls.wait_timeout = 120
+        cls.wait_timeout = 360
+        cls.poll_interval = 5
 
     def setUp(self):
         self.log_path = '{}/logging'.format(self.testing_root)
@@ -68,6 +69,13 @@ class TestJobsControllerGoogle(BaseTestCases.JobsControllerTestCase):
             outputs=outputs,
             outputs_recursive=outputs_recursive,
             wait=wait)
+
+    def test_abort_job(self):
+        started = self.start_job('sleep 30')
+        api_job_id = self.get_api_job_id(started)
+        self.wait_for_job_status(api_job_id, ApiStatus.RUNNING)
+        self.must_abort_job(api_job_id)
+        self.wait_for_job_status(api_job_id, ApiStatus.ABORTED)
 
     def test_query_jobs_invalid_project(self):
         params = QueryJobsRequest(

--- a/servers/dsub/jobs/test/test_jobs_controller_local.py
+++ b/servers/dsub/jobs/test/test_jobs_controller_local.py
@@ -56,6 +56,8 @@ class TestJobsControllerLocal(BaseTestCases.JobsControllerTestCase):
     def test_abort_job(self):
         started = self.start_job('sleep 30')
         api_job_id = self.get_api_job_id(started)
+        # TODO(https://github.com/googlegenomics/dsub/issues/101): Remove
+        # this sleep once the local and google statuses are consistent
         time.sleep(10)
         self.wait_for_job_status(api_job_id, ApiStatus.RUNNING)
         self.must_abort_job(api_job_id)

--- a/servers/dsub/jobs/test/test_jobs_controller_local.py
+++ b/servers/dsub/jobs/test/test_jobs_controller_local.py
@@ -53,6 +53,14 @@ class TestJobsControllerLocal(BaseTestCases.JobsControllerTestCase):
             return job.labels['status-detail'] != PROCESS_NOT_FOUND_MESSAGE
         return has_status
 
+    def test_abort_job(self):
+        started = self.start_job('sleep 30')
+        api_job_id = self.get_api_job_id(started)
+        time.sleep(10)
+        self.wait_for_job_status(api_job_id, ApiStatus.RUNNING)
+        self.must_abort_job(api_job_id)
+        self.wait_for_job_status(api_job_id, ApiStatus.ABORTED)
+
     def test_get_succeeded_job(self):
         inputs_dir = '{}/inputs'.format(self.testing_root)
         outputs_dir = '{}/outputs'.format(self.testing_root)


### PR DESCRIPTION
#### Resolves #172 
- Increase timeout for google jobs to start to 5 minutes, should fix issues with jobs not being `RUNNING` after 2 minutes
- Reduce poll interval for local provider tests and add sleep to ensure job has started, fixing silent docker error:
```
Error response from daemon: Cannot kill container: dsub-sleep--circleci--180104-010812-353250: No such container: dsub-sleep--circleci--180104-010812-353250
```