### PR TITLE
[dsub] Support querying by reserved labels and URL-prefixed projects fix

### DIFF
--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -95,10 +95,10 @@ def get_job(id):
 
     # A job_id and task_id define a unique job (should only be one)
     if len(jobs) > 1:
-        raise BadRequest('Found more than one job with ID {}:{}'.format(
+        raise BadRequest('Found more than one job with ID {}+{}'.format(
             job_id, task_id))
     elif len(jobs) == 0:
-        raise NotFound('Could not find any jobs with ID {}:{}'.format(
+        raise NotFound('Could not find any jobs with ID {}+{}'.format(
             job_id, task_id))
     return _metadata_response(id, jobs[0])
 
@@ -139,9 +139,12 @@ def query_jobs(body):
         jobs = dstat.dstat_job_producer(
             provider=provider,
             statuses=dstat_params['statuses'],
-            create_time=dstat_params['create_time'],
-            job_names=dstat_params['job_names'],
-            labels=dstat_params['labels'],
+            user_ids=dstat_params.get('user_ids'),
+            job_ids=dstat_params.get('job_ids'),
+            task_ids=dstat_params.get('task_ids'),
+            create_time=dstat_params.get('create_time'),
+            job_names=dstat_params.get('job_names'),
+            labels=dstat_params.get('labels'),
             full_output=True,
             max_tasks=max_tasks).next()
     except apiclient.errors.HttpError as error:

--- a/servers/dsub/jobs/controllers/utils/job_ids.py
+++ b/servers/dsub/jobs/controllers/utils/job_ids.py
@@ -20,11 +20,11 @@ def api_to_dsub(api_id, provider_type):
             BadRequest if the api_id format is invalid for the given provider
     """
     project, job, task = None, None, None
-    id_split = api_id.split(":")
+    id_split = api_id.split('+')
 
     if provider_type == ProviderType.GOOGLE:
         # If we are running on Google cloud the id format should be:
-        # <project-id>:<job-id>:<task-id> or <project-id>:<job-id> if there is
+        # <project-id>+<job-id>+<task-id> or <project-id>+<job-id> if there is
         # no task ID
         if len(id_split) == 2:
             project, job = id_split
@@ -32,9 +32,9 @@ def api_to_dsub(api_id, provider_type):
             project, job, task = id_split
         else:
             raise BadRequest('Job ID format for google provider is: ' +
-                             '<project-id>:<job-id>[:<task-id>]?')
+                             '<project-id>+<job-id>[+<task-id>]?')
     else:
-        # Otherwise, the id format should be: <job-id>:<task-id> or <job-id> if
+        # Otherwise, the id format should be: <job-id>+<task-id> or <job-id> if
         # there is no task ID
         if len(id_split) == 1:
             job = id_split[0]
@@ -42,7 +42,7 @@ def api_to_dsub(api_id, provider_type):
             job, task = id_split
         else:
             raise BadRequest('Job ID format for non-google provider is: ' +
-                             '<job-id>[:<task-id>]?')
+                             '<job-id>[+<task-id>]?')
 
     return project, job, task
 
@@ -62,11 +62,11 @@ def dsub_to_api(proj_id, job_id, task_id):
             BadRequest if no job_id is provided
     """
     if proj_id and job_id and task_id:
-        return '{}:{}:{}'.format(proj_id, job_id, task_id)
+        return '{}+{}+{}'.format(proj_id, job_id, task_id)
     elif proj_id and job_id:
-        return '{}:{}'.format(proj_id, job_id)
+        return '{}+{}'.format(proj_id, job_id)
     elif job_id and task_id:
-        return '{}:{}'.format(job_id, task_id)
+        return '{}+{}'.format(job_id, task_id)
     elif job_id:
         return job_id
     else:

--- a/servers/dsub/jobs/controllers/utils/labels.py
+++ b/servers/dsub/jobs/controllers/utils/labels.py
@@ -16,4 +16,9 @@ def dsub_to_api(job):
         labels['last-update'] = job['last-update']
     if 'user-id' in job:
         labels['user-id'] = job['user-id']
+    if 'job-id' in job:
+        labels['job-id'] = job['job-id']
+    if 'task-id' in job:
+        labels['task-id'] = job['task-id']
+
     return labels

--- a/servers/dsub/jobs/controllers/utils/query_parameters.py
+++ b/servers/dsub/jobs/controllers/utils/query_parameters.py
@@ -29,18 +29,13 @@ def api_to_dsub(query):
     if query.name:
         dstat_params['job_names'] = {query.name}
     if query.labels:
-        dstat_params['job_ids'] = {
-            v
-            for (k, v) in query.labels.items() if k == 'job-id'
-        }
-        dstat_params['task_ids'] = {
-            v
-            for (k, v) in query.labels.items() if k == 'task-id'
-        }
-        dstat_params['user_ids'] = {
-            v
-            for (k, v) in query.labels.items() if k == 'user-id'
-        }
+        if query.labels.get('job-id'):
+            dstat_params['job_ids'] = {query.labels['job-id']}
+        if query.labels.get('task-id'):
+            dstat_params['task_ids'] = {query.labels['task-id']}
+        if query.labels.get('user-id'):
+            dstat_params['user_ids'] = {query.labels['user-id']}
+
         dstat_params['labels'] = {
             param_util.LabelParam(k, v)
             for (k, v) in query.labels.items()

--- a/servers/dsub/jobs/controllers/utils/query_parameters.py
+++ b/servers/dsub/jobs/controllers/utils/query_parameters.py
@@ -24,13 +24,27 @@ def api_to_dsub(query):
 
     if query.start:
         epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=tzutc())
-        dstat_params['create_time'] = int((query.start - epoch).total_seconds())
+        dstat_params['create_time'] = int(
+            (query.start - epoch).total_seconds())
     if query.name:
         dstat_params['job_names'] = {query.name}
     if query.labels:
-        dstat_params['job_ids'] = {v for (k, v) in query.labels.items() if k == 'job-id'}
-        dstat_params['task_ids'] = {v for (k, v) in query.labels.items() if k == 'task-id'}
-        dstat_params['user_ids'] = {v for (k, v) in query.labels.items() if k == 'user-id'}
-        dstat_params['labels'] = {param_util.LabelParam(k, v) for (k, v) in query.labels.items() if k not in ['job-id', 'task-id', 'user-id']}
+        dstat_params['job_ids'] = {
+            v
+            for (k, v) in query.labels.items() if k == 'job-id'
+        }
+        dstat_params['task_ids'] = {
+            v
+            for (k, v) in query.labels.items() if k == 'task-id'
+        }
+        dstat_params['user_ids'] = {
+            v
+            for (k, v) in query.labels.items() if k == 'user-id'
+        }
+        dstat_params['labels'] = {
+            param_util.LabelParam(k, v)
+            for (k, v) in query.labels.items()
+            if k not in ['job-id', 'task-id', 'user-id']
+        }
 
     return dstat_params

--- a/servers/dsub/jobs/controllers/utils/query_parameters.py
+++ b/servers/dsub/jobs/controllers/utils/query_parameters.py
@@ -17,20 +17,20 @@ def api_to_dsub(query):
 
     dstat_params = {}
 
-    epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=tzutc())
-    dstat_params['create_time'] = int(
-        (query.start - epoch).total_seconds()) if query.start else None
-
-    dstat_params['job_names'] = {query.name} if query.name else None
-
     dstat_params['statuses'] = {
         job_statuses.api_to_dsub(s)
         for s in query.statuses
     } if query.statuses else {'*'}
 
-    dstat_params['labels'] = {
-        param_util.LabelParam(k, v)
-        for (k, v) in query.labels.items()
-    } if query.labels else None
+    if query.start:
+        epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=tzutc())
+        dstat_params['create_time'] = int((query.start - epoch).total_seconds())
+    if query.name:
+        dstat_params['job_names'] = {query.name}
+    if query.labels:
+        dstat_params['job_ids'] = {v for (k, v) in query.labels.items() if k == 'job-id'}
+        dstat_params['task_ids'] = {v for (k, v) in query.labels.items() if k == 'task-id'}
+        dstat_params['user_ids'] = {v for (k, v) in query.labels.items() if k == 'user-id'}
+        dstat_params['labels'] = {param_util.LabelParam(k, v) for (k, v) in query.labels.items() if k not in ['job-id', 'task-id', 'user-id']}
 
     return dstat_params

--- a/servers/dsub/jobs/test/base_test_cases.py
+++ b/servers/dsub/jobs/test/base_test_cases.py
@@ -72,7 +72,9 @@ class BaseTestCases:
 
         def get_api_job_id(self, dsub_job):
             if self.testing_project and dsub_job.get('task-id'):
-                return '{}+{}+{}'.format(self.testing_project, dsub_job['job-id'], dsub_job['task-id'])
+                return '{}+{}+{}'.format(self.testing_project,
+                                         dsub_job['job-id'],
+                                         dsub_job['task-id'])
             elif self.testing_project:
                 return '{}+{}'.format(self.testing_project, dsub_job['job-id'])
             elif dsub_job.get('task-id'):
@@ -152,7 +154,9 @@ class BaseTestCases:
             }
 
             if task_count > 1:
-                all_task_data = [{'task-id': i+1} for i in xrange(task_count)]
+                all_task_data = [{
+                    'task-id': i + 1
+                } for i in xrange(task_count)]
             else:
                 all_task_data = [job_data]
 
@@ -285,19 +289,32 @@ class BaseTestCases:
 
         def test_query_jobs_by_label_job_id(self):
             job = self.start_job('echo BY_JOB_ID', name='by_job_id')
-            self.assert_query_matches(QueryJobsRequest(labels={'job-id' : job['job-id']}), [job])
+            self.assert_query_matches(
+                QueryJobsRequest(labels={
+                    'job-id': job['job-id']
+                }), [job])
 
         def test_query_jobs_by_label_task_id(self):
-            started = self.start_job('echo BY_TASK_ID', name='by_task_id', task_count=2)
-            jobs = self.must_query_jobs(QueryJobsRequest(labels={'job-id' : started['job-id']}))
+            started = self.start_job(
+                'echo BY_TASK_ID', name='by_task_id', task_count=2)
+            jobs = self.must_query_jobs(
+                QueryJobsRequest(labels={
+                    'job-id': started['job-id']
+                }))
             for task_id in started['task-id']:
                 task = started.copy()
                 task['task-id'] = task_id
-                self.assert_query_matches(QueryJobsRequest(labels={'task-id' : task_id}), [task])
+                self.assert_query_matches(
+                    QueryJobsRequest(labels={
+                        'task-id': task_id
+                    }), [task])
 
         def test_query_jobs_by_label_user_id(self):
             job = self.start_job('echo BY_USER_ID', name='by_user_id')
-            self.assert_query_matches(QueryJobsRequest(labels={'user-id' : job['user-id']}), [job])
+            self.assert_query_matches(
+                QueryJobsRequest(labels={
+                    'user-id': job['user-id']
+                }), [job])
 
         def test_query_jobs_by_label(self):
             labels = {

--- a/servers/dsub/jobs/test/base_test_cases.py
+++ b/servers/dsub/jobs/test/base_test_cases.py
@@ -11,6 +11,7 @@ import string
 import time
 
 from jobs.common import execute_redirect_stdout
+from jobs.controllers.utils import job_ids
 from jobs.controllers.utils.job_statuses import ApiStatus
 from jobs.encoder import JSONEncoder
 from jobs.models.job_metadata_response import JobMetadataResponse
@@ -71,16 +72,9 @@ class BaseTestCases:
             }
 
         def get_api_job_id(self, dsub_job):
-            if self.testing_project and dsub_job.get('task-id'):
-                return '{}+{}+{}'.format(self.testing_project,
-                                         dsub_job['job-id'],
-                                         dsub_job['task-id'])
-            elif self.testing_project:
-                return '{}+{}'.format(self.testing_project, dsub_job['job-id'])
-            elif dsub_job.get('task-id'):
-                return '{}+{}'.format(dsub_job['job-id'], dsub_job['task-id'])
-            else:
-                return dsub_job['job-id']
+            return job_ids.dsub_to_api(self.testing_project,
+                                       dsub_job.get('job-id'),
+                                       dsub_job.get('task-id'))
 
         def job_has_status(self, job, status):
             return job.status == status
@@ -231,6 +225,7 @@ class BaseTestCases:
                 outputs=outputs)
             api_job_id = self.get_api_job_id(started)
             self.wait_for_job_status(api_job_id, ApiStatus.SUCCEEDED)
+
             # Get job and validate that the metadata is accurate
             job = self.must_get_job(api_job_id)
             self.assertEqual(job.id, api_job_id)

--- a/servers/dsub/jobs/test/test_jobs_controller_google.py
+++ b/servers/dsub/jobs/test/test_jobs_controller_google.py
@@ -57,6 +57,7 @@ class TestJobsControllerGoogle(BaseTestCases.JobsControllerTestCase):
                   inputs_recursive={},
                   outputs={},
                   outputs_recursive={},
+                  task_count=1,
                   wait=False):
         labels.update(self.test_token_label)
         return super(TestJobsControllerGoogle, self).start_job(
@@ -68,6 +69,7 @@ class TestJobsControllerGoogle(BaseTestCases.JobsControllerTestCase):
             inputs_recursive=inputs_recursive,
             outputs=outputs,
             outputs_recursive=outputs_recursive,
+            task_count=task_count,
             wait=wait)
 
     def test_abort_job(self):

--- a/ui/src/app/job-details/panels/panels.component.html
+++ b/ui/src/app/job-details/panels/panels.component.html
@@ -1,7 +1,7 @@
 <div class="content">
   <div>
       <p class="header">{{ job.name }}</p>
-      <p class="job-id">Job ID: <b>{{ job.id }}</b></p>
+      <p class="job-id">ID: <b>{{ job.id }}</b></p>
       <span *ngFor="let l of labels">
         <p class="text-info">{{ l + ': ' + job.labels[l] }}</p>
       </span>

--- a/ui/src/environments/environment.dsub.google.ts
+++ b/ui/src/environments/environment.dsub.google.ts
@@ -5,6 +5,6 @@ export const environment = {
   production: false,
   requiresAuth: true,
   scope: 'https://www.googleapis.com/auth/genomics https://www.googleapis.com/auth/cloudplatformprojects.readonly',
-  additionalColumns: ['user-id'],
+  additionalColumns: ['user-id', 'job-id', 'task-id'],
   entryPoint: 'projects',
 };

--- a/ui/src/environments/environment.dsub.local.ts
+++ b/ui/src/environments/environment.dsub.local.ts
@@ -4,6 +4,6 @@ export const environment = {
   production: false,
   requiresAuth: false,
   scope: '',
-  additionalColumns: ['user-id'],
+  additionalColumns: ['user-id', 'job-id', 'task-id'],
   entryPoint: 'jobs',
 };


### PR DESCRIPTION
### Resolves #169 
- Support querying by `user-id`, `job-id`, and `task-id` labels. These are considered first class fields in `dstat`, but are jammed into `labels` in the common API. We have to translate back when querying by them.
- Add tests validating behavior and ensuring querying multi-tasks jobs works
- Also add `job-id` and `task-id` columns to the jobs list page. This will allow users to more easily construct queries for say all the running tasks left on a single dsub job. 
### Resolves #157 
- Use a `+` rather than `:` to join components since projects with a URL prefix use a `:` to join.