### PR TITLE
[CI] Run detox tests with 8 parallel processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,11 @@ jobs:
           name: Run dsub server tests
           command: |
             if [ -z "$GCLOUD_SERVICE_KEY" ]; then
-              detox -c ./servers/dsub -- \
+              detox -n 8 -c ./servers/dsub -- \
                 --exclude-test=jobs.test.test_jobs_controller_google.TestJobsControllerGoogle
             else
               echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > /home/circleci/gcloud-service-key.json
-              detox -c ./servers/dsub
+              detox -n 8 -c ./servers/dsub
               rm /home/circleci/gcloud-service-key.json
             fi
       - run:


### PR DESCRIPTION
The CircleCI VMs have 2 cores which is used as the [default](https://github.com/tox-dev/detox/blob/master/detox/tox_proclimit.py#L17) number of parallel processes for `detox` . The dsub integration tests are not computationally intensive, they just take a while to wait for jobs to be started on google cloud. More concurrency should theoretically speed this up.