### PR TITLE
Fix local dsub not starting up

### DIFF
--- a/servers/dsub/Dockerfile.local
+++ b/servers/dsub/Dockerfile.local
@@ -21,6 +21,8 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
 RUN apt-get update
 RUN apt-get install -y docker-ce
+# We installed jm_utils so don't need local copy anymore, which breaks imports
+RUN rm -rf jm_utils
 
 # Missing required arguments -b PORT, -e ... which must be provided by the
 # docker image user.

--- a/servers/dsub/Dockerfile.local
+++ b/servers/dsub/Dockerfile.local
@@ -11,6 +11,8 @@ ADD jm_utils /app/jm_utils
 ADD dsub/jobs /app/jobs
 ADD dsub/requirements.txt /app/jobs
 RUN cd jobs && pip install -r requirements.txt
+# We installed jm_utils so don't need local copy anymore, which breaks imports
+RUN rm -rf jm_utils
 
 # Install docker-ce for dsub local provider
 RUN apt-get update
@@ -21,8 +23,6 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
 RUN apt-get update
 RUN apt-get install -y docker-ce
-# We installed jm_utils so don't need local copy anymore, which breaks imports
-RUN rm -rf jm_utils
 
 # Missing required arguments -b PORT, -e ... which must be provided by the
 # docker image user.


### PR DESCRIPTION
On my machine, sometimes local dsub failed to start up [1].

I'm able to repro with:
- ln -sf dsub-local-compose.yml docker-compose.yml
- docker-compose build dsub
- docker-compose up

Dockerfile.local was missing "rm -rf jm_utils". The other Dockerfile's have this. So the container had jm_utils in 2 places: /home/vmagent/app/jm_utils and in /env/lib/python2.7/site-packages. Due to syspath ordering, former is picked up. Former didn't have page_tokens.

I believe others weren't seeing this -- even with local dsub -- because depending on ordering of commands, their container might have had "rm -rf jm_utils" from Google-dsub Dockerfile.

[1]
Starting jobmanager_dsub_1 ... done
Attaching to jobmanager_dsub_1
dsub_1        | [2018-01-17 01:08:30 +0000] [1296] [INFO] Starting gunicorn 19.7.1
dsub_1        | [2018-01-17 01:08:30 +0000] [1296] [INFO] Listening at: http://0.0.0.0:8190 (1296)
dsub_1        | [2018-01-17 01:08:30 +0000] [1296] [INFO] Using worker: sync
dsub_1        | [2018-01-17 01:08:30 +0000] [1372] [INFO] Booting worker with pid: 1372
dsub_1        | [2018-01-17 01:08:31 +0000] [1372] [ERROR] Exception in worker process
dsub_1        | Traceback (most recent call last):
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 578, in spawn_worker
dsub_1        |     worker.init_process()
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 126, in init_process
dsub_1        |     self.load_wsgi()
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 135, in load_wsgi
dsub_1        |     self.wsgi = self.app.wsgi()
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
dsub_1        |     self.callable = self.load()
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 65, in load
dsub_1        |     return self.load_wsgiapp()
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
dsub_1        |     return util.import_app(self.app_uri)
dsub_1        |   File "/env/local/lib/python2.7/site-packages/gunicorn/util.py", line 352, in import_app
dsub_1        |     __import__(module)
dsub_1        |   File "/home/vmagent/app/jobs/__main__.py", line 84, in <module>
dsub_1        |     app.add_api('swagger.yaml', base_path=args.path_prefix)
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/apps/flask_app.py", line 54, in add_api
dsub_1        |     api = super(FlaskApp, self).add_api(specification, **kwargs)
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/apps/abstract.py", line 159, in add_api
dsub_1        |     options=api_options.as_dict())
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/apis/abstract.py", line 131, in __init__
dsub_1        |     self.add_paths()
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/apis/abstract.py", line 249, in add_paths
dsub_1        |     self._handle_add_operation_error(path, method, err.exc_info)
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/apis/abstract.py", line 263, in _handle_add_operation_error
dsub_1        |     six.reraise(*exc_info)
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/resolver.py", line 62, in resolve_function_from_operation_id
dsub_1        |     return self.function_resolver(operation_id)
dsub_1        |   File "/env/local/lib/python2.7/site-packages/connexion/utils.py", line 46, in get_function_from_name
dsub_1        |     raise last_import_error
dsub_1        | ImportError: cannot import name page_tokens
dsub_1        | [2018-01-17 01:08:31 +0000] [1372] [INFO] Worker exiting (pid: 1372)
dsub_1        | [2018-01-17 01:08:31 +0000] [1296] [INFO] Shutting down: Master
dsub_1        | [2018-01-17 01:08:31 +0000] [1296] [INFO] Reason: Worker failed to boot.
jobmanager_dsub_1 exited with code 3
