### PR TITLE
List Cromwell jobs from newest to oldest 

### DIFF
--- a/common-compose.yml
+++ b/common-compose.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - 8190:8190
   cromwell:
-    command: ["-b", ":8190"]
+    command: ["-b", ":8190", "-t", "60"]
     environment:
       - PATH_PREFIX=/api/v1
       - CROMWELL_CREDENTIALS=/app/jobs/config.json

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -482,7 +482,7 @@ class TestJobsController(BaseTestCase):
 
         def _request_callback(request, context):
             context.status_code = 200
-            return {'results': []}
+            return {'results': [], 'totalResultsCount': 0}
 
         query_url = self.base_url + '/query'
         mock_request.post(query_url, json=_request_callback)


### PR DESCRIPTION
The Cromwell `query` endpoint returns jobs from oldest to newest, but we want to display jobs from newest to oldest in the UI. 

This PR updates the `query` endpoint in the translation layer to: 
1. Make a request to the query endpoint to get the `totalResultsCount`. 
2. Calculate which page to request from the API based on the total number of pages and the current page in the UI, so that the results are retrieved from newest to oldest.
3. Query the Cromwell API (filtering out subworkflows) and continue getting results if the initial amount returned is less than `query.page_size`. 

Notes:
- This request can take 30+ seconds if there are a lot of subworkflows in the page of results that is requested, so this PR also increases the `timeout` in gunicorn to 60 seconds (the default is 30s)
- Including the ability to filter out subworkflows in Cromwell would allow us to make fewer requests to get the number of jobs we want to display. Here's the open issue in the Cromwell repo: https://github.com/broadinstitute/cromwell/issues/3240

**This requires first updating the staging Cromwell to the latest hotfix that includes the `totalResultsCount` key.**

