### PR TITLE
Upgrade to Angular 5

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -47,24 +47,17 @@
       }
     },
     "@angular/animations": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-4.4.6.tgz",
-      "integrity": "sha1-+mYYmaik44y3xYPHpcl85l1ZKjU=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.3.tgz",
+      "integrity": "sha512-K9rOsRGwt7Zmp/rNdvBmgBKqvEdgCyZF0kvwxrmZfq1Zj0GAkfTAKPL007493O6XFd+icfu/+kmYeqXBGB4gKA==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/cdk": {
-      "version": "2.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-2.0.0-beta.12.tgz",
-      "integrity": "sha1-OiQ8tiuT9OA5EgunD5ANyeI1Yi4=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.2.0.tgz",
+      "integrity": "sha1-Q2j2dJ6RXNzHXTJa4z/bP4WogQg=",
       "requires": {
         "tslib": "1.9.0"
       }
@@ -136,44 +129,31 @@
       }
     },
     "@angular/common": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.4.6.tgz",
-      "integrity": "sha1-S4FCByTggooOg5uVpV6xp+g5GPI=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.3.tgz",
+      "integrity": "sha512-RwQ/IjmpDdMecTz/wwQlKpHgF4Crr8kyqV9FJ+c+cHR8Riqlu2DOXSU7LIfDdGoo6Mpixdxd1rtHYfs7l9YBSA==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/compiler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.4.6.tgz",
-      "integrity": "sha1-LuH68lt1fh0SiXkHS+f65SmzvCA=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.3.tgz",
+      "integrity": "sha512-OynSzUdEHwajQMoV2JuYq5IdiR2dlTCTAHhTLzrym85wOihvTvovEQwVhYYHyKERu85JIoaF1sXA42KIjMGfkw==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.4.6.tgz",
-      "integrity": "sha1-uv09HiYOmQh+uajPdTLb1gOrubE=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.3.tgz",
+      "integrity": "sha512-uoCxeyQSd8R/cwEbd0FIUXjnbPq0HXEsyu3WSu9Ek2jt52HL+x/gZQdFCRtjW/mvQNOqxrgrTtEkhJ398+VkXg==",
       "dev": true,
       "requires": {
-        "@angular/tsc-wrapped": "4.4.6",
+        "chokidar": "1.7.0",
         "minimist": "1.2.0",
-        "reflect-metadata": "0.1.10"
+        "reflect-metadata": "0.1.10",
+        "tsickle": "0.26.0"
       },
       "dependencies": {
         "minimist": {
@@ -181,127 +161,81 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "tsickle": {
+          "version": "0.26.0",
+          "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.26.0.tgz",
+          "integrity": "sha512-eWJ2CUfttGK0LqF9iJ/Avnxbj4M+fCyJ50Zag3wm73Fut1hsasPRHKxKdrMWVj4BMHnQNx7TO+DdNmLmJTSuNw==",
+          "dev": true,
+          "requires": {
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "source-map": "0.5.7",
+            "source-map-support": "0.4.18"
+          }
         }
       }
     },
     "@angular/core": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.4.6.tgz",
-      "integrity": "sha1-EwMf0Q3P5DiHVBmzjyESCVi8I1Q=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.3.tgz",
+      "integrity": "sha512-tL9O8KA6KGjnlxqjuTytpC2OeKbxe/yHev0kmwo5CK0lDZU4UFetcItAzUXU1dyRuILTcBkbnFt9+nr1SZs/cQ==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/forms": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.4.6.tgz",
-      "integrity": "sha1-/mSs5CQ1wbgPSQNLfEHOjK8UpEo=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.3.tgz",
+      "integrity": "sha512-PsMGbj/Slvsxxyl61QSSSFDCGHN1XK6kNxVQTVmAlVhP1LlaYqBOIgQy4K9CYWUeHqU/YCdhVaFb5quzZLtPYA==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/http": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-4.4.6.tgz",
-      "integrity": "sha1-CvaAxnEL3AJtlA4iXP0PalwAXQw=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.2.3.tgz",
+      "integrity": "sha512-3kAj7YYws8J2zRu46fEXk6lYrgSK9s5YA6O4REZkLox/suK0wb6TsDIIhoMzScGctSzZESVyuWsvYMrDYCflPA==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/language-service": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-4.4.6.tgz",
-      "integrity": "sha1-SY7OlcX2BmQDv5/TxYMa9CtFYYs=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-5.2.3.tgz",
+      "integrity": "sha512-yBi8i2rUdq6WgYn2J+82QxqhKsl2ldH7/8Lk4ZQDbKgTBx5LmYLpNGg3TJGnZEUGtKhu8Rd1E3SBmc4qqrGXsQ==",
       "dev": true
     },
     "@angular/material": {
-      "version": "2.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-2.0.0-beta.12.tgz",
-      "integrity": "sha1-cbbQt7AhiR5dDjaIwdS9eMdFf1g=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-5.2.0.tgz",
+      "integrity": "sha1-hZnjFJ1ISH4+kulB+p3FUXbjoM8=",
       "requires": {
         "tslib": "1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-        }
       }
     },
     "@angular/platform-browser": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.4.6.tgz",
-      "integrity": "sha1-qYOcVH4bZU+h0kqJeAyLpquNzOA=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.3.tgz",
+      "integrity": "sha512-60LgA4KK3BufBR7vwwcn3zTYuLlfDG3jFip7bvdgsDpURrUB0j6/pL5cbGElww4jnnxZ72uJzJRzSiGEofjc3g==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.4.6.tgz",
-      "integrity": "sha1-TT2aanvyzz3kBYphWuBZ7/ZB+jY=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.3.tgz",
+      "integrity": "sha512-PheS+KJQJiyvQg1lr+eX0/1b/rjLnDjgI1qvzwikrvGYymb2JdZ+rjllHBs1iotzQ+tG+hRnlktvgdFN134x/g==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
+        "tslib": "1.9.0"
       }
     },
     "@angular/router": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-4.4.6.tgz",
-      "integrity": "sha1-D2rSmuD/jSyeo3m9MgRHIXt+yGY=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.2.3.tgz",
+      "integrity": "sha512-XVEpwNZta76FYas1gZSSGvkQoiGgQjvXfab6CwOh958d4c0C+9pJsykqsv6X/n8TSTShQt7wjs/vp/copXeuoA==",
       "requires": {
-        "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
-        }
-      }
-    },
-    "@angular/tsc-wrapped": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.4.6.tgz",
-      "integrity": "sha1-Fnh8u/UL3H5zgSOxnDJSfyROF40=",
-      "dev": true,
-      "requires": {
-        "tsickle": "0.21.6"
+        "tslib": "1.9.0"
       }
     },
     "@ngtools/json-schema": {
@@ -13394,58 +13328,6 @@
         }
       }
     },
-    "tsickle": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
-      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
-      "dev": true,
-      "requires": {
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map": "0.5.7",
-        "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        }
-      }
-    },
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
@@ -13806,9 +13688,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
     "uglify-js": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,25 +13,25 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^4.4.3",
-    "@angular/cdk": "2.0.0-beta.12",
-    "@angular/common": "^4.2.4",
-    "@angular/compiler": "^4.2.4",
-    "@angular/core": "^4.2.4",
-    "@angular/forms": "^4.2.4",
-    "@angular/http": "^4.2.4",
-    "@angular/material": "2.0.0-beta.12",
-    "@angular/platform-browser": "^4.2.4",
-    "@angular/platform-browser-dynamic": "^4.2.4",
-    "@angular/router": "^4.2.4",
+    "@angular/animations": "^5.2.0",
+    "@angular/cdk": "^5.2.0",
+    "@angular/common": "^5.2.0",
+    "@angular/compiler": "^5.2.0",
+    "@angular/core": "^5.2.0",
+    "@angular/forms": "^5.2.0",
+    "@angular/http": "^5.2.0",
+    "@angular/material": "^5.2.0",
+    "@angular/platform-browser": "^5.2.0",
+    "@angular/platform-browser-dynamic": "^5.2.0",
+    "@angular/router": "^5.2.0",
     "core-js": "^2.5.3",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.20"
   },
   "devDependencies": {
     "@angular/cli": "^1.6.5",
-    "@angular/compiler-cli": "^4.2.4",
-    "@angular/language-service": "^4.2.4",
+    "@angular/compiler-cli": "^5.2.0",
+    "@angular/language-service": "^5.2.0",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^6.0.96",
@@ -49,6 +49,6 @@
     "tslint": "~5.3.2",
     "tslint-consistent-codestyle": "^1.11.0",
     "tslint-eslint-rules": "^4.1.1",
-    "typescript": "~2.3.3"
+    "typescript": "~2.4.0"
   }
 }

--- a/ui/src/app/projects/projects.component.css
+++ b/ui/src/app/projects/projects.component.css
@@ -25,10 +25,6 @@ p {
   text-align: center;
 }
 
-.mat-option {
-  width: 30%;
-}
-
 .project-name {
   text-align: center;
 }

--- a/ui/src/app/projects/projects.component.ts
+++ b/ui/src/app/projects/projects.component.ts
@@ -35,7 +35,7 @@ import {URLSearchParamsUtils} from "../shared/utils/url-search-params.utils";
 export class ProjectsComponent implements OnInit {
   @ViewChild('auto') auto: ElementRef;
   projectsControl: FormControl;
-  projectsObservable: Observable<any[]>;
+  projectsObservable: Observable<void|any[]>;
   projects: any[];
   viewJobsEnabled = false;
 

--- a/ui/src/app/shared/job-stream.ts
+++ b/ui/src/app/shared/job-stream.ts
@@ -12,7 +12,7 @@ export class JobStream extends BehaviorSubject<JobListView> {
   // A backend query promise which represents the pending or most recent backend
   // response. All requests synchronize through this promise to avoid duplicate
   // data loading.
-  private queryPromise: Promise<QueryJobsResponse> = Promise.resolve({});
+  private queryPromise: Promise<QueryJobsResponse> = Promise.resolve({results: []});
 
   // This class handles pagination, so the request's paging info need not be defined.
   constructor(private jobManagerService: JobManagerService,


### PR DESCRIPTION
Went through the app and this didn't seem to break anything, surprisingly (aside from the project dropdown 30% width FYI @bfcrampton, in case I missed the purpose of that). Also required bumping TS to 2.4.

The latest angular release contains a paginator option for hiding pageSize, which is what we'd like to have on the jobs table.