### PR TITLE
Fix angular types error

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -277,6 +277,11 @@
         }
       }
     },
+    "@types/angular": {
+      "version": "1.6.42",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.42.tgz",
+      "integrity": "sha512-JKx/tYYWzVRGQs/FF9Jo55VsF9Vb4D2/CMS1M6fyWOI1dq0dLzt0obJfmxtbgBgjBVzcBJW0ikMJ8oz96Dx7Ow=="
+    },
     "@types/jasmine": {
       "version": "2.5.54",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.54.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
+    "@types/angular": "^1.6.42",
     "core-js": "^2.5.3",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.20"


### PR DESCRIPTION
Include `@types/angular` to resolve the following build error:

```
docker-compose -f dsub-google-compose.yml up
Recreating jobmanager_ui_1 ... 
Starting jobmanager_dsub_1 ... 
Recreating jobmanager_ui_1
Recreating jobmanager_ui_1 ... done
Recreating jobmanager_jobs-proxy_1 ... 
Recreating jobmanager_jobs-proxy_1 ... done
Attaching to jobmanager_dsub_1, jobmanager_ui_1, jobmanager_jobs-proxy_1
dsub_1        | [2018-02-07 18:45:54 +0000] [1] [INFO] Starting gunicorn 19.7.1
dsub_1        | [2018-02-07 18:45:54 +0000] [1] [INFO] Listening at: http://0.0.0.0:8190 (1)
ui_1          | npm info it worked if it ends with ok
ui_1          | npm info using npm@5.3.0
ui_1          | npm info using node@v8.5.0
dsub_1        | [2018-02-07 18:45:54 +0000] [1] [INFO] Using worker: sync
dsub_1        | [2018-02-07 18:45:54 +0000] [11] [INFO] Booting worker with pid: 11
ui_1          | npm info lifecycle job-manager-ui@0.0.1~preng: job-manager-ui@0.0.1
ui_1          | npm info lifecycle job-manager-ui@0.0.1~ng: job-manager-ui@0.0.1
ui_1          | 
ui_1          | > job-manager-ui@0.0.1 ng /ui
ui_1          | > ng "serve" "--host" "ui" "--env=dsub_google"
ui_1          | 
ui_1          | ** NG Live Development Server is listening on ui:4200, open your browser on http://ui:4200/ **
ui_1          | Date: 2018-02-07T18:46:02.403Z
ui_1          | Hash: 5bd70bb346f5ae451fc4
ui_1          | Time: 4959ms
ui_1          | chunk {inline} inline.bundle.js (inline) 5.79 kB [entry] [rendered]
ui_1          | chunk {main} main.bundle.js (main) 2.93 kB [initial] [rendered]
ui_1          | chunk {polyfills} polyfills.bundle.js (polyfills) 636 bytes [initial] [rendered]
ui_1          | chunk {styles} styles.bundle.js (styles) 183 kB [initial] [rendered]
ui_1          | chunk {vendor} vendor.bundle.js (vendor) 852 kB [initial] [rendered]
ui_1          | 
ui_1          | ERROR in error TS2688: Cannot find type definition file for 'angular'.
ui_1          | 
ui_1          | 
ui_1          | webpack: Failed to compile.
```