### PR TITLE
Move paginator to the header

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -280,7 +280,8 @@
     "@types/angular": {
       "version": "1.6.42",
       "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.42.tgz",
-      "integrity": "sha512-JKx/tYYWzVRGQs/FF9Jo55VsF9Vb4D2/CMS1M6fyWOI1dq0dLzt0obJfmxtbgBgjBVzcBJW0ikMJ8oz96Dx7Ow=="
+      "integrity": "sha512-JKx/tYYWzVRGQs/FF9Jo55VsF9Vb4D2/CMS1M6fyWOI1dq0dLzt0obJfmxtbgBgjBVzcBJW0ikMJ8oz96Dx7Ow==",
+      "dev": true
     },
     "@types/jasmine": {
       "version": "2.5.54",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,6 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
-    "@types/angular": "^1.6.42",
     "core-js": "^2.5.3",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.20"
@@ -33,6 +32,7 @@
     "@angular/cli": "^1.6.5",
     "@angular/compiler-cli": "^5.2.0",
     "@angular/language-service": "^5.2.0",
+    "@types/angular": "^1.6.42",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^6.0.96",

--- a/ui/src/app/job-details/job-details.component.html
+++ b/ui/src/app/job-details/job-details.component.html
@@ -1,4 +1,4 @@
-<jm-header></jm-header>
+<jm-header [showControls]="false"></jm-header>
 <jm-panels [job]="job"></jm-panels>
 <!-- Only show the tasks table if there is at least 1 task. -->
 <jm-tasks *ngIf="hasTasks()" [tasks]="job.tasks" [jobId]="job.id"></jm-tasks>

--- a/ui/src/app/job-list/job-list.component.html
+++ b/ui/src/app/job-list/job-list.component.html
@@ -1,4 +1,5 @@
 <jm-header
+  [showControls]="true"
   [jobs]="jobs"
   [pageSize]="pageSize"></jm-header>
 <jm-job-list-table [dataSource]="dataSource">

--- a/ui/src/app/job-list/job-list.component.html
+++ b/ui/src/app/job-list/job-list.component.html
@@ -1,5 +1,5 @@
-<jm-header></jm-header>
-<jm-job-list-table
+<jm-header
   [jobs]="jobs"
-  (onPage)="onClientPaginate($event)">
+  [pageSize]="pageSize"></jm-header>
+<jm-job-list-table [dataSource]="dataSource">
 </jm-job-list-table>

--- a/ui/src/app/job-list/job-list.component.html
+++ b/ui/src/app/job-list/job-list.component.html
@@ -2,5 +2,7 @@
   [showControls]="true"
   [jobs]="jobs"
   [pageSize]="pageSize"></jm-header>
-<jm-job-list-table [dataSource]="dataSource">
+<jm-job-list-table
+  [dataSource]="dataSource"
+  (onJobsChanged)="handleJobsChanged(jobs)">
 </jm-job-list-table>

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -207,7 +207,7 @@ describe('JobListComponent', () => {
   }));
 
   @Component({
-    selector: 'app',
+    selector: 'jm-test-app',
     template: '<router-outlet></router-outlet>'
   })
   class AppComponent {}

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -36,7 +36,7 @@ describe('JobListComponent', () => {
       status: JobStatus.Running,
       submission: new Date('2015-04-20T20:00:00')
     };
-    return (new Array(5)).map((_, i) => {
+    return (new Array(5)).fill(null).map((_, i) => {
       return {
         ...base,
         id: `JOB${i}`

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -124,7 +124,7 @@ describe('JobListComponent', () => {
     expectJobsRendered(fakeJobService.jobs.slice(0, 3));
   }));
 
-  it('paginates properly', fakeAsync(() => {
+  it('paginates forward', fakeAsync(() => {
     fakeJobService.jobs = testJobs(5);
     tick();
     fixture.detectChanges();
@@ -134,6 +134,15 @@ describe('JobListComponent', () => {
 
     // Page 2.
     expectJobsRendered(fakeJobService.jobs.slice(3, 5));
+  }));
+
+  it('paginates backwards', fakeAsync(() => {
+    fakeJobService.jobs = testJobs(5);
+    tick();
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement;
+    de.query(By.css('.mat-paginator-increment')).nativeElement.click();
+    fixture.detectChanges();
 
     // Back to page 1, which should have the first 3 jobs.
     de.query(By.css('.mat-paginator-decrement')).nativeElement.click();
@@ -162,16 +171,21 @@ describe('JobListComponent', () => {
     tick();
     fixture.detectChanges();
 
+    // Filter by active to filter out jobs after they've been aborted.
     let de: DebugElement = fixture.debugElement;
     de.query(By.css('.active-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
 
+    // We select the first page (3 jobs) and abort. Jobs 3 and 4 are unaffected.
     de.query(By.css('jm-job-list-table')).componentInstance.toggleSelectAll();
     fixture.detectChanges();
     de.query(By.css('.group-abort')).nativeElement.click();
     tick();
     fixture.detectChanges();
+
+    // Jobs 3 and 4 should be the only jobs displayed, as they are the only
+    // remaining active jobs.
     expectJobsRendered(jobs.slice(3, 5));
   }));
 

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -2,7 +2,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
 import {DataSource} from '@angular/cdk/collections';
-import {Component, OnInit, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, Input, OnInit, ViewChild, ViewContainerRef} from '@angular/core';
 import {PageEvent, MatPaginator, MatSnackBar} from '@angular/material'
 import {Observable} from 'rxjs/Observable';
 import {ActivatedRoute, NavigationError, Router} from '@angular/router';
@@ -22,7 +22,7 @@ import {QueryJobsResult} from '../shared/model/QueryJobsResult';
   styleUrls: ['./job-list.component.css'],
 })
 export class JobListComponent implements OnInit {
-  readonly pageSize = 25;
+  @Input() pageSize: number = 50;
 
   @ViewChild(HeaderComponent) header: HeaderComponent;
   dataSource: DataSource<QueryJobsResult>;
@@ -72,8 +72,8 @@ export class JobListComponent implements OnInit {
         .then(() => {
           // Only subscribe after the initial page load finishes, to avoid
           // briefly loading an empty list of jobs.
+          this.header.resetPagination();
           this.streamSubscription = this.jobStream.subscribe(this.jobs);
-          this.header.resetPagination()
         })
         .catch(error => this.handleError(error));
     }

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -1,15 +1,20 @@
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
+import {DataSource} from '@angular/cdk/collections';
 import {Component, OnInit, ViewChild, ViewContainerRef} from '@angular/core';
-import {PageEvent, MatSnackBar} from '@angular/material'
+import {PageEvent, MatPaginator, MatSnackBar} from '@angular/material'
+import {Observable} from 'rxjs/Observable';
 import {ActivatedRoute, NavigationError, Router} from '@angular/router';
 
 import {JobManagerService} from '../core/job-manager.service';
 import {ErrorMessageFormatterPipe} from '../shared/pipes/error-message-formatter.pipe';
 import {JobsTableComponent} from './table/table.component';
 import {JobListView, JobStream} from '../shared/job-stream';
+import {HeaderComponent} from '../shared/header/header.component';
 import {URLSearchParamsUtils} from "../shared/utils/url-search-params.utils";
 import {initialBackendPageSize} from "../shared/common";
+import {QueryJobsResult} from '../shared/model/QueryJobsResult';
 
 @Component({
   selector: 'jm-job-list',
@@ -17,17 +22,19 @@ import {initialBackendPageSize} from "../shared/common";
   styleUrls: ['./job-list.component.css'],
 })
 export class JobListComponent implements OnInit {
-  @ViewChild(JobsTableComponent) table: JobsTableComponent;
+  readonly pageSize = 25;
 
-  private jobStream: JobStream;
-  private streamSubscription: Subscription;
+  @ViewChild(HeaderComponent) header: HeaderComponent;
+  dataSource: DataSource<QueryJobsResult>;
 
   // This Subject is synchronized to a JobStream, which we destroy and recreate
   // whenever we change query parameters, via a subscription.
-  public jobs = new BehaviorSubject<JobListView>({
+  private jobs = new BehaviorSubject<JobListView>({
     results: [],
     exhaustive: false
   });
+  private jobStream: JobStream;
+  private streamSubscription: Subscription;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -42,6 +49,12 @@ export class JobListComponent implements OnInit {
   ngOnInit(): void {
     this.jobStream = this.route.snapshot.data['stream'];
     this.streamSubscription = this.jobStream.subscribe(resp => this.jobs.next(resp));
+    this.header.pageSubject.subscribe(resp => this.onClientPaginate(resp));
+    this.dataSource = new JobsDataSource(this.jobs, this.header.pageSubject, {
+      pageSize: this.pageSize,
+      pageIndex: 0,
+      length: 0,
+    });
     // Handle navigation errors raised in JobDetailsResolver
     this.router.events.subscribe(event => {
       if (event instanceof NavigationError) {
@@ -54,10 +67,15 @@ export class JobListComponent implements OnInit {
     if (this.streamSubscription) {
       this.streamSubscription.unsubscribe();
       this.jobStream = new JobStream(this.jobManagerService,
-        URLSearchParamsUtils.unpackURLSearchParams(query));
-      this.streamSubscription = this.jobStream.subscribe(resp => this.jobs.next(resp));
+          URLSearchParamsUtils.unpackURLSearchParams(query));
       this.jobStream.loadAtLeast(initialBackendPageSize)
-        .catch((error) => this.handleError(error));
+        .then(() => {
+          // Only subscribe after the initial page load finishes, to avoid
+          // briefly loading an empty list of jobs.
+          this.streamSubscription = this.jobStream.subscribe(this.jobs);
+          this.header.resetPagination()
+        })
+        .catch(error => this.handleError(error));
     }
   }
 
@@ -68,10 +86,39 @@ export class JobListComponent implements OnInit {
       {viewContainerRef: this.viewContainer});
   }
 
-  public onClientPaginate(e: PageEvent) {
+  handleJobsChanged(jobs: QueryJobsResult[]) {
+    this.reloadJobs(this.route.snapshot.queryParams['q']);
+  }
+
+  private onClientPaginate(e: PageEvent) {
     // If the client just navigated to page n, ensure we have enough jobs to
     // display page n+1.
     this.jobStream.loadAtLeast((e.pageIndex+2) * e.pageSize)
       .catch((error) => this.handleError(error));
   }
+}
+
+
+/** DataSource providing the list of jobs to be rendered in the table. */
+export class JobsDataSource extends DataSource<QueryJobsResult> {
+
+  constructor(
+    private backendJobs: BehaviorSubject<JobListView>,
+    private pageSubject: Subject<PageEvent>,
+    private lastPageEvent: PageEvent) {
+    super();
+  }
+
+  connect(): Observable<QueryJobsResult[]> {
+    const p = this.pageSubject.map((e) => this.lastPageEvent = e);
+    return Observable.merge(this.backendJobs, p).map(() => {
+      const data = this.backendJobs.value.results.slice();
+
+      // Get only the requested page
+      const startIndex = this.lastPageEvent.pageIndex * this.lastPageEvent.pageSize;
+      return data.splice(startIndex, this.lastPageEvent.pageSize);
+    });
+  }
+
+  disconnect() {}
 }

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -85,5 +85,5 @@
 <div class="group-options" *ngIf="canAbortAnySelected()">
   {{ selection.selected.length }} jobs selected
   <button mat-raised-button color="accent" class="group-button group-abort"
-          (click)="onAbortJobs(selectedJobs)">Abort Jobs</button>
+          (click)="onAbortJobs()">Abort Jobs</button>
 </div>

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -5,8 +5,8 @@
     <mat-header-cell *matHeaderCellDef>
       <mat-checkbox class = "checkbox"
                     (change)="$event ? toggleSelectAll() : null"
-                    [checked]="selection.hasValue() && allSelected()"
-                    [indeterminate]="selection.hasValue() && !allSelected()">
+                    [checked]="allSelected()"
+                    [indeterminate]="partiallySelected()">
       </mat-checkbox>
       Job
     </mat-header-cell>

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -12,7 +12,6 @@
     </mat-header-cell>
     <mat-cell *matCellDef="let j">
       <mat-checkbox class = "checkbox"
-                    (click)="$event.stopPropagation()"
                     (change)="$event ? selection.toggle(j) : null"
                     [checked]="selection.isSelected(j)">
       </mat-checkbox>

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -3,12 +3,18 @@
   <!-- Job name column -->
   <ng-container matColumnDef="Job">
     <mat-header-cell *matHeaderCellDef>
-      <mat-checkbox class = "checkbox" [checked]="allSelected" (change)="toggleSelectAll()">
+      <mat-checkbox class = "checkbox"
+                    (change)="$event ? toggleSelectAll() : null"
+                    [checked]="selection.hasValue() && allSelected()"
+                    [indeterminate]="selection.hasValue() && !allSelected()">
       </mat-checkbox>
       Job
     </mat-header-cell>
     <mat-cell *matCellDef="let j">
-      <mat-checkbox class = "checkbox" [checked]="isSelected(j)" (change)="toggleSelect(j)">
+      <mat-checkbox class = "checkbox"
+                    (click)="$event.stopPropagation()"
+                    (change)="$event ? selection.toggle(j) : null"
+                    [checked]="selection.isSelected(j)">
       </mat-checkbox>
       <a mat-button class="job-details-button" [routerLink]="[j.id]" [queryParams]="getQueryParams()">{{ j.name }}</a>
 
@@ -69,23 +75,16 @@
 
   <!-- Column definitions -->
   <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-  <mat-row (mouseenter) ="toggleMouseOver(j)"
-          (mouseleave) ="toggleMouseOver(j)"
-          [class.selected-row]="isSelected(j)"
-          class = "mat-row"
-          *matRowDef="let j; columns: displayedColumns;"></mat-row>
+  <mat-row class = "mat-row"
+           (mouseenter) ="toggleMouseOver(j)"
+           (mouseleave) ="toggleMouseOver(j)"
+           [class.selected-row]="selection.isSelected(j)"
+           *matRowDef="let j; columns: displayedColumns;"></mat-row>
 
 </mat-table>
 
-<div class="group-options" *ngIf="selectedJobs.length > 0">
-  {{ selectedJobs.length }} jobs selected
+<div class="group-options" *ngIf="canAbortAnySelected()">
+  {{ selection.selected.length }} jobs selected
   <button mat-raised-button color="accent" class="group-button group-abort"
           (click)="onAbortJobs(selectedJobs)">Abort Jobs</button>
 </div>
-
-<mat-paginator #paginator
-              [length]="jobs.value.results.length"
-              [pageIndex]="0"
-              [pageSize]="10"
-              [pageSizeOptions]="[5, 10, 25, 100]">
-</mat-paginator>

--- a/ui/src/app/job-list/table/table.component.spec.ts
+++ b/ui/src/app/job-list/table/table.component.spec.ts
@@ -34,45 +34,49 @@ describe('JobsTableComponent', () => {
 
   let testComponent: TestTableComponent;
   let fixture: ComponentFixture<TestTableComponent>;
-  let testJob1: QueryJobsResult = {
-    id: 'JOB1',
-    name: 'TCG-NBL-7357',
-    status: JobStatus.Running,
-    submission: new Date('2015-04-20T20:00:00'),
-    start: new Date('1994-03-29T21:00:00'),
-    labels: {'user-id': 'user-1', 'status-detail': 'status-detail-1'}};
-  let testJobs: QueryJobsResult[] =
-    [
-      testJob1,
-      { id: 'JOB2',
-        name: 'AML-G4-CHEN',
-        status: JobStatus.Submitted,
-        submission: new Date('2015-04-20T20:00:00'),
-        labels: {'user-id': 'user-2', 'status-detail': 'status-detail-2'}},
-      { id: 'JOB3',
-        name: 'TCG-NBL-B887',
-        status: JobStatus.Aborted,
-        submission: new Date('2015-04-20T20:00:00'),
-        start: new Date('2015-04-20T21:00:00'),
-        end: new Date('2015-04-20T22:00:00'),
-        labels: {'user-id': 'user-3', 'status-detail': 'status-detail-3'}},
-      { id: 'JOB4',
-        name: 'TARGET-CCSK',
-        status: JobStatus.Succeeded,
-        submission: new Date('2015-04-20T20:00:00'),
-        start: new Date('2015-04-20T21:00:00'),
-        end: new Date('2015-04-20T22:00:00'),
-        labels: {'user-id': 'user-4', 'status-detail': 'status-detail-4'}},
-      { id: 'JOB5',
-        name: '1543LKF678',
-        status: JobStatus.Failed,
-        submission: new Date('2015-04-20T20:00:00'),
-        start: new Date('2015-04-20T21:00:00'),
-        end: new Date('2015-04-20T22:00:00')}
-    ];
+  let jobs: QueryJobsResult[];
+
+  function testJobs(count: number): QueryJobsResult[] {
+    return [{
+      id: 'JOB1',
+      name: 'TCG-NBL-7357',
+      status: JobStatus.Running,
+      submission: new Date('2015-04-20T20:00:00'),
+      start: new Date('1994-03-29T21:00:00'),
+      labels: {'user-id': 'user-1', 'status-detail': 'status-detail-1'}
+    }, {
+      id: 'JOB2',
+      name: 'AML-G4-CHEN',
+      status: JobStatus.Submitted,
+      submission: new Date('2015-04-20T20:00:00'),
+      labels: {'user-id': 'user-2', 'status-detail': 'status-detail-2'}
+    }, {
+      id: 'JOB3',
+      name: 'TCG-NBL-B887',
+      status: JobStatus.Aborted,
+      submission: new Date('2015-04-20T20:00:00'),
+      start: new Date('2015-04-20T21:00:00'),
+      end: new Date('2015-04-20T22:00:00'),
+      labels: {'user-id': 'user-3', 'status-detail': 'status-detail-3'}
+    }, {
+      id: 'JOB4',
+      name: 'TARGET-CCSK',
+      status: JobStatus.Succeeded,
+      submission: new Date('2015-04-20T20:00:00'),
+      start: new Date('2015-04-20T21:00:00'),
+      end: new Date('2015-04-20T22:00:00'),
+      labels: {'user-id': 'user-4', 'status-detail': 'status-detail-4'}
+    }, {
+      id: 'JOB5',
+      name: '1543LKF678',
+      status: JobStatus.Failed,
+      submission: new Date('2015-04-20T20:00:00'),
+      start: new Date('2015-04-20T21:00:00'),
+      end: new Date('2015-04-20T22:00:00')
+    }];
+  }
 
   beforeEach(async(() => {
-
     TestBed.configureTestingModule({
       declarations: [
         JobsTableComponent,
@@ -107,20 +111,22 @@ describe('JobsTableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TestTableComponent);
     testComponent = fixture.componentInstance;
+    jobs = testJobs();
+    testComponent.jobs.next(jobs);
   });
 
   it('should display a row for each job', async(() => {
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
-    expect(de.queryAll(By.css('.mat-row')).length).toEqual(testJobs.length);
+    expect(de.queryAll(By.css('.mat-row')).length).toEqual(jobs.length);
   }));
 
   it('should display general job data in row', async(() => {
-    testComponent.jobs.next([testJob1]);
+    testComponent.jobs.next([jobs[0]]);
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
     expect(de.query(By.css('.job-details-button')).nativeElement.textContent)
-      .toEqual(testJob1.name);
+      .toEqual(jobs[0].name);
     expect(de.query(By.css('#submitted-column')).nativeElement.textContent)
       .toContain('8:00 PM');
     expect(de.queryAll(By.css('.additional-column')).length).toEqual(0);
@@ -128,24 +134,46 @@ describe('JobsTableComponent', () => {
 
   it('should display dsub-specific job data in row', async(() => {
     environment.additionalColumns = ['user-id', 'status-detail'];
-    testComponent.jobs.next([testJob1]);
+    testComponent.jobs.next([jobs[0]]);
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
     expect(de.query(By.css('.job-details-button')).nativeElement.textContent)
-      .toEqual(testJob1.name);
+      .toEqual(jobs[0].name);
     let dsubColumns = de.queryAll(By.css('.additional-column'));
     expect(dsubColumns.length).toEqual(2);
     expect(dsubColumns[0].nativeElement.textContent)
-      .toEqual(testJob1.labels['user-id']);
+      .toEqual(jobs[0].labels['user-id']);
     expect(dsubColumns[1].nativeElement.textContent)
-      .toEqual(testJob1.labels['status-detail']);
+      .toEqual(jobs[0].labels['status-detail']);
   }));
 
   it('displays the abort button for selected active jobs', async(() => {
+    // None selected.
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
     expect(de.queryAll(By.css('.group-abort')).length).toEqual(0);
+
+    // All selected, none abortable.
+    for (let j of jobs) {
+      j.status = JobStatus.Succeeded;
+    }
+    testComponent.jobs.next(jobs);
+    testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
+    expect(de.queryAll(By.css('.group-abort')).length).toEqual(0);
+
+    // All selected, 1 abortable.
+    jobs[2].status = JobStatus.Running;
+    testComponent.jobs.next(jobs);
+    testComponent.jobsTableComponent.toggleSelectAll();
+    fixture.detectChanges();
+    expect(de.queryAll(By.css('.group-abort')).length).toEqual(1);
+
+    // All selected, all abortable.
+    for (let j of jobs) {
+      j.status = JobStatus.Running;
+    }
+    testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
     expect(de.queryAll(By.css('.group-abort')).length).toEqual(1);
@@ -172,7 +200,7 @@ describe('JobsTableComponent', () => {
       `<jm-job-list-table [dataSource]="dataSource"></jm-job-list-table>`
   })
   class TestTableComponent {
-    public jobs = new BehaviorSubject<QueryJobsResult[]>(testJobs);
+    public jobs = new BehaviorSubject<QueryJobsResult[]>([]);
     public dataSource = new TestDataSource(this.jobs);
     @ViewChild(JobsTableComponent)
     public jobsTableComponent: JobsTableComponent;

--- a/ui/src/app/job-list/table/table.component.spec.ts
+++ b/ui/src/app/job-list/table/table.component.spec.ts
@@ -115,6 +115,10 @@ describe('JobsTableComponent', () => {
     testComponent.jobs.next(jobs);
   });
 
+  function isGroupAbortRendered(): boolean {
+    return fixture.debugElement.queryAll(By.css('.group-abort')).length > 0;
+  }
+
   it('should display a row for each job', async(() => {
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
@@ -147,37 +151,38 @@ describe('JobsTableComponent', () => {
       .toEqual(jobs[0].labels['status-detail']);
   }));
 
-  it('displays the abort button for selected active jobs', async(() => {
-    // None selected.
+  it('hides the abort button on 0 selection', async(() => {
     fixture.detectChanges();
-    let de: DebugElement = fixture.debugElement;
-    expect(de.queryAll(By.css('.group-abort')).length).toEqual(0);
+    expect(isGroupAbortRendered()).toBeFalse();
+  }))
 
-    // All selected, none abortable.
+  it('hides the abort button for non-abortable selection', async(() => {
     for (let j of jobs) {
       j.status = JobStatus.Succeeded;
     }
     testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
-    expect(de.queryAll(By.css('.group-abort')).length).toEqual(0);
+    expect(isGroupAbortRendered()).toBeFalse();
+  }))
 
-    // All selected, 1 abortable.
+  it('shows the abort button when some selected are abortable', async(() => {
     jobs[2].status = JobStatus.Running;
     testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
-    expect(de.queryAll(By.css('.group-abort')).length).toEqual(1);
+    expect(isGroupAbortRendered()).toBeTrue();
+  }))
 
-    // All selected, all abortable.
+  it('shows the abort button when all selected are abortable', async(() => {
     for (let j of jobs) {
       j.status = JobStatus.Running;
     }
     testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
-    expect(de.queryAll(By.css('.group-abort')).length).toEqual(1);
-  }));
+    expect(isGroupAbortRendered()).toBeTrue();
+  }))
 
   it ('displays error message bar', async(() => {
     let error = {

--- a/ui/src/app/job-list/table/table.component.spec.ts
+++ b/ui/src/app/job-list/table/table.component.spec.ts
@@ -111,7 +111,7 @@ describe('JobsTableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TestTableComponent);
     testComponent = fixture.componentInstance;
-    jobs = testJobs();
+    jobs = testJobs(5);
     testComponent.jobs.next(jobs);
   });
 
@@ -153,35 +153,38 @@ describe('JobsTableComponent', () => {
 
   it('hides the abort button on 0 selection', async(() => {
     fixture.detectChanges();
-    expect(isGroupAbortRendered()).toBeFalse();
+    expect(isGroupAbortRendered()).toBeFalsy();
   }))
 
   it('hides the abort button for non-abortable selection', async(() => {
+    fixture.detectChanges();
     for (let j of jobs) {
       j.status = JobStatus.Succeeded;
     }
     testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
-    expect(isGroupAbortRendered()).toBeFalse();
+    expect(isGroupAbortRendered()).toBeFalsy();
   }))
 
   it('shows the abort button when some selected are abortable', async(() => {
+    fixture.detectChanges();
     jobs[2].status = JobStatus.Running;
     testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
-    expect(isGroupAbortRendered()).toBeTrue();
+    expect(isGroupAbortRendered()).toBeTruthy();
   }))
 
   it('shows the abort button when all selected are abortable', async(() => {
+    fixture.detectChanges();
     for (let j of jobs) {
       j.status = JobStatus.Running;
     }
     testComponent.jobs.next(jobs);
     testComponent.jobsTableComponent.toggleSelectAll();
     fixture.detectChanges();
-    expect(isGroupAbortRendered()).toBeTrue();
+    expect(isGroupAbortRendered()).toBeTruthy();
   }))
 
   it ('displays error message bar', async(() => {

--- a/ui/src/app/job-list/table/table.component.spec.ts
+++ b/ui/src/app/job-list/table/table.component.spec.ts
@@ -164,21 +164,6 @@ describe('JobsTableComponent', () => {
       .toEqual("Precondition Failed (412): Job already in terminal status `FAILED` Dismiss");
   }))
 
-// XXX: mv this test
-//  it('should only show length for exhaustive job streams', async(() => {
-//    testComponent.jobs.next([testJob1]);
-//    fixture.detectChanges();
-//    let de: DebugElement = fixture.debugElement;
-//    expect(de.query(By.css('.mat-paginator-range-label')).nativeElement.textContent)
-//      .toContain('of many');
-//
-//    // Transition to exhaustive, "of X" should now display length.
-//    testComponent.jobs.next([testJob1, testJob1]);
-//    fixture.detectChanges();
-//    expect(de.query(By.css('.mat-paginator-range-label')).nativeElement.textContent)
-//      .toContain('of 2');
-//  }));
-
   // TODO(alanhwang): Add unit tests for component logic
 
   @Component({

--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -31,7 +31,6 @@ import {JobStatus} from '../../shared/model/JobStatus';
 import {QueryJobsResult} from '../../shared/model/QueryJobsResult';
 import {ErrorMessageFormatterPipe} from '../../shared/pipes/error-message-formatter.pipe';
 import {JobStatusImage, primaryColumns} from '../../shared/common';
-import {JobListView} from '../../shared/job-stream';
 import {ActivatedRoute, Params} from '@angular/router';
 import {environment} from '../../../environments/environment';
 

--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -155,8 +155,15 @@ export class JobsTableComponent implements OnInit {
     }
   }
 
+  /** Whether all jobs are selected. False if no jobs are displayed. */
   allSelected(): boolean {
-    return this.selection.selected.length === this.jobs.length;
+    return this.selection.hasValue() &&
+      this.selection.selected.length === this.jobs.length;
+  }
+
+  /** Whether some, but not all, jobs are selected. */
+  partiallySelected(): boolean {
+    return selection.hasValue() && !allSelected();
   }
 
   toggleSelectAll(): void {

--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -139,7 +139,7 @@ export class JobsTableComponent implements OnInit {
     }
     Promise.all(aborts)
       .then(() => this.onJobsChanged.emit(selected))
-      .error((errs) => this.handleErrorMessage(
+      .catch((errs) => this.handleErrorMessage(
         `failed to abort ${errs.length}/${selected.length} jobs`));
   }
 
@@ -163,7 +163,7 @@ export class JobsTableComponent implements OnInit {
 
   /** Whether some, but not all, jobs are selected. */
   partiallySelected(): boolean {
-    return selection.hasValue() && !allSelected();
+    return this.selection.hasValue() && !this.allSelected();
   }
 
   toggleSelectAll(): void {

--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -11,7 +11,7 @@ import {
   ViewChild,
   ViewContainerRef
 } from '@angular/core';
-import {DataSource} from '@angular/cdk/collections';
+import {DataSource, SelectionModel} from '@angular/cdk/collections';
 import {
   MatPaginator,
   MatPaginatorIntl,
@@ -40,22 +40,18 @@ import {environment} from '../../../environments/environment';
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.css'],
 })
-export class JobsTableComponent implements OnInit, OnDestroy {
-  @Input() jobs: BehaviorSubject<JobListView>;
-  @Output() onPage = new EventEmitter<PageEvent>();
+export class JobsTableComponent implements OnInit {
+  @Input() dataSource: DataSource<QueryJobsResult>;
+  @Output() onJobsChanged: EventEmitter<QueryJobsResult[]> = new EventEmitter();
 
-  private pageSubscription: Subscription;
   private mouseoverJob: QueryJobsResult;
 
   public additionalColumns: string[] = [];
-  public allSelected: boolean = false;
-  public selectedJobs: QueryJobsResult[] = [];
+  public selection = new SelectionModel<QueryJobsResult>(/* allowMultiSelect */ true, []);
+  public jobs: QueryJobsResult[] = [];
 
-  dataSource: JobsDataSource | null;
   // TODO(alanhwang): Allow these columns to be configured by the user
   displayedColumns = primaryColumns.slice();
-
-  @ViewChild(MatPaginator) paginator: MatPaginator;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -65,32 +61,16 @@ export class JobsTableComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    // Our paginator details depend on the state of backend pagination,
-    // therefore we cannot simply inject an alternate MatPaginatorIntl, as
-    // recommended by the paginator documentation. _intl is public, and
-    // overwriting it seems preferable to providing our own version of
-    // MatPaginator.
-    this.paginator._intl = new JobsPaginatorIntl(
-      this.jobs, this.paginator._intl.changes);
-    this.dataSource = new JobsDataSource(this.jobs, this.paginator);
+    this.dataSource.connect(null).subscribe((jobs: QueryJobsResult[]) => {
+      this.jobs = jobs;
+      this.selection.clear();
+    });
     if (environment.additionalColumns) {
       this.additionalColumns = environment.additionalColumns;
     }
     for (let column of this.additionalColumns) {
       this.displayedColumns.push(column);
     }
-    this.pageSubscription =
-      this.paginator.page.subscribe((e) => this.onPage.emit(e));
-  }
-
-  ngOnDestroy() {
-    this.pageSubscription.unsubscribe();
-  }
-
-  private onJobsChanged(): void {
-    this.allSelected = false;
-    this.selectedJobs = [];
-    this.paginator.pageIndex = 0;
   }
 
   handleError(error: any) {
@@ -113,6 +93,15 @@ export class JobsTableComponent implements OnInit, OnDestroy {
     return job.status == JobStatus.Submitted || job.status == JobStatus.Running;
   }
 
+  canAbortAnySelected(): boolean {
+    for (let j of this.selection.selected) {
+      if (this.canAbort(j)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   getDropdownArrowUrl(): string {
     return "https://www.gstatic.com/images/icons/material/system/1x/arrow_drop_down_grey700_24dp.png"
   }
@@ -132,17 +121,13 @@ export class JobsTableComponent implements OnInit, OnDestroy {
     return JobStatusImage[status];
   }
 
-  isSelected(job: QueryJobsResult): boolean {
-    return this.selectedJobs.indexOf(job) > -1;
-  }
-
   onAbortJobs(jobs: QueryJobsResult[]): void {
     for (let job of jobs) {
       if (job.status == JobStatus.Running || job.status == JobStatus.Submitted) {
         this.abortJob(job);
       }
     }
-    this.onJobsChanged();
+    this.onJobsChanged.emit(jobs);
   }
 
   showDropdownArrow(job: QueryJobsResult): boolean {
@@ -157,83 +142,15 @@ export class JobsTableComponent implements OnInit, OnDestroy {
     }
   }
 
-  toggleSelect(job: QueryJobsResult): void {
-    if (this.isSelected(job)) {
-      this.selectedJobs
-        .splice(this.selectedJobs.indexOf(job), 1);
-      this.allSelected = false;
-    } else {
-      this.selectedJobs.push(job);
-    }
+  allSelected(): boolean {
+    return this.selection.selected.length === this.jobs.length;
   }
 
   toggleSelectAll(): void {
-    if (this.allSelected) {
-      this.selectedJobs = [];
-      this.allSelected = false;
+    if (this.allSelected()) {
+      this.selection.clear();
     } else {
-      this.selectedJobs = this.jobs.value.results.slice();
-      this.allSelected = true;
+      this.jobs.forEach(j => this.selection.select(j));
     }
   }
-}
-
-/**
- * Paginator details for the jobs table. Accounts for the case where we haven't
- * loaded all jobs (matching the query) onto the client; we need to indicate
- * this rather than showing a misleading count for the number of jobs that have
- * been loaded onto the client so far.
- */
-export class JobsPaginatorIntl extends MatPaginatorIntl {
-  private defaultIntl = new MatPaginatorIntl()
-
-  constructor(private backendJobs: BehaviorSubject<JobListView>,
-              public changes: Subject<void>) {
-    super();
-    backendJobs.subscribe((jobList: JobListView) => {
-      // Ensure that the paginator component is redrawn once we transition to
-      // an exhaustive list of jobs.
-      if (jobList.exhaustive) {
-        changes.next();
-      }
-    });
-  }
-
-  getRangeLabel = (page: number, pageSize: number, length: number) => {
-    if (this.backendJobs.value.exhaustive) {
-      // Can't use proper inheritance here, since MatPaginatorIntl only defines
-      // properties, rather than class methods.
-      return this.defaultIntl.getRangeLabel(page, pageSize, length);
-    }
-    // Ported from MatPaginatorIntl - boundary checks likely unneeded.
-    const startIndex = page * pageSize;
-    const endIndex = startIndex < length ?
-        Math.min(startIndex + pageSize, length) :
-        startIndex + pageSize;
-    return `${startIndex + 1} - ${endIndex} of many`;
-  }
-}
-
-/** DataSource providing the list of jobs to be rendered in the table. */
-export class JobsDataSource extends DataSource<any> {
-
-  constructor(private backendJobs: BehaviorSubject<JobListView>, private paginator: MatPaginator) {
-    super();
-  }
-
-  connect(): Observable<QueryJobsResult[]> {
-    const displayDataChanges = [
-      this.backendJobs,
-      this.paginator.page,
-    ];
-    return Observable.merge(...displayDataChanges).map(() => {
-      const data = this.backendJobs.value.results.slice();
-
-      // Get only the requested page
-      const startIndex = this.paginator.pageIndex * this.paginator.pageSize;
-      return data.splice(startIndex, this.paginator.pageSize);
-    });
-  }
-
-  disconnect() {}
 }

--- a/ui/src/app/shared/header/header.component.css
+++ b/ui/src/app/shared/header/header.component.css
@@ -20,3 +20,9 @@
   width: 7rem;
   margin-right: .5rem;
 }
+
+.search-table-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -72,4 +72,13 @@
     <button mat-raised-button class="status-button" (click)="showFailedJobs()">FAILED</button>
     <button mat-raised-button class="status-button" (click)="showCompletedJobs()">COMPLETED</button>
   </div>
+
+  <div>
+    <mat-paginator #paginator
+                   [length]="jobs.value.results.length"
+                   [pageIndex]="0"
+                   [pageSize]="pageSize"
+                   [hidePageSize]="true">
+    </mat-paginator>
+  </div>
 </div>

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -71,9 +71,9 @@
     <!-- Always include child divs, to support flex box style placement. -->
     <div>
       <ng-container *ngIf="shouldDisplayStatusButtons()">
-        <button mat-raised-button class="status-button" (click)="showActiveJobs()">ACTIVE</button>
-        <button mat-raised-button class="status-button" (click)="showFailedJobs()">FAILED</button>
-        <button mat-raised-button class="status-button" (click)="showCompletedJobs()">COMPLETED</button>
+        <button mat-raised-button class="status-button active-button" (click)="showActiveJobs()">ACTIVE</button>
+        <button mat-raised-button class="status-button failed-button" (click)="showFailedJobs()">FAILED</button>
+        <button mat-raised-button class="status-button completed-button" (click)="showCompletedJobs()">COMPLETED</button>
       </ng-container>
    </div>
 

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -67,14 +67,14 @@
     </button>
   </mat-form-field>
 
-  <div *ngIf="shouldDisplayStatusButtons()">
-    <button mat-raised-button class="status-button" (click)="showActiveJobs()">ACTIVE</button>
-    <button mat-raised-button class="status-button" (click)="showFailedJobs()">FAILED</button>
-    <button mat-raised-button class="status-button" (click)="showCompletedJobs()">COMPLETED</button>
-  </div>
+  <div class="search-table-controls">
+    <div *ngIf="shouldDisplayStatusButtons()">
+      <button mat-raised-button class="status-button" (click)="showActiveJobs()">ACTIVE</button>
+      <button mat-raised-button class="status-button" (click)="showFailedJobs()">FAILED</button>
+      <button mat-raised-button class="status-button" (click)="showCompletedJobs()">COMPLETED</button>
+    </div>
 
-  <div>
-    <mat-paginator #paginator
+    <mat-paginator *ngIf="jobs" #paginator
                    [length]="jobs.value.results.length"
                    [pageIndex]="0"
                    [pageSize]="pageSize"

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -67,18 +67,23 @@
     </button>
   </mat-form-field>
 
-  <div class="search-table-controls">
-    <div *ngIf="shouldDisplayStatusButtons()">
-      <button mat-raised-button class="status-button" (click)="showActiveJobs()">ACTIVE</button>
-      <button mat-raised-button class="status-button" (click)="showFailedJobs()">FAILED</button>
-      <button mat-raised-button class="status-button" (click)="showCompletedJobs()">COMPLETED</button>
-    </div>
+  <div *ngIf="showControls" class="search-table-controls">
+    <!-- Always include child divs, to support flex box style placement. -->
+    <div>
+      <ng-container *ngIf="shouldDisplayStatusButtons()">
+        <button mat-raised-button class="status-button" (click)="showActiveJobs()">ACTIVE</button>
+        <button mat-raised-button class="status-button" (click)="showFailedJobs()">FAILED</button>
+        <button mat-raised-button class="status-button" (click)="showCompletedJobs()">COMPLETED</button>
+      </ng-container>
+   </div>
 
-    <mat-paginator *ngIf="jobs" #paginator
-                   [length]="jobs.value.results.length"
-                   [pageIndex]="0"
-                   [pageSize]="pageSize"
-                   [hidePageSize]="true">
-    </mat-paginator>
+    <div>
+      <mat-paginator #paginator
+                     [length]="jobs.value.results.length"
+                     [pageIndex]="0"
+                     [pageSize]="pageSize"
+                     [hidePageSize]="true">
+      </mat-paginator>
+    </div>
   </div>
 </div>

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -12,17 +12,33 @@ import {
   MatListModule,
   MatMenuModule,
   MatNativeDateModule,
+  MatPaginatorModule,
 } from "@angular/material";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {RouterTestingModule} from "@angular/router/testing";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
+import {JobListView} from "../job-stream";
 import {HeaderComponent} from "./header.component";
 import {startCol, statusesCol} from "../common";
+import {QueryJobsResult} from '../model/QueryJobsResult';
 import {JobStatus} from "../model/JobStatus";
 
 
 describe('HeaderComponent', () => {
+  const baseJob = {
+    status: JobStatus.Running,
+    submission: new Date('2015-04-20T20:00:00'),
+  }
+  const testJob1: QueryJobsResult = { ...baseJob, id: 'JOB1' };
+  const testJob2: QueryJobsResult = { ...baseJob, id: 'JOB2' };
+  const testJob3: QueryJobsResult = { ...baseJob, id: 'JOB3' };
+
+  const initJobs = {
+    results: [testJob1, testJob2, testJob3],
+    exhaustive: false
+  }
 
   let testComponent: HeaderComponent;
   let fixture: ComponentFixture<TestHeaderComponent>;
@@ -44,6 +60,7 @@ describe('HeaderComponent', () => {
         MatListModule,
         MatMenuModule,
         MatNativeDateModule,
+        MatPaginatorModule,
         ReactiveFormsModule,
         RouterTestingModule.withRoutes([
           {path: '', component: TestHeaderComponent}
@@ -52,14 +69,15 @@ describe('HeaderComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
+  beforeEach(async(() => {
     fixture = TestBed.createComponent(TestHeaderComponent);
     testComponent = fixture.componentInstance.headerComponent;
     testComponent.chips = new Map()
       .set('parent-id', 'Parent ID')
       .set('job-name', 'Job Name')
       .set('statuses', 'Running');
-  });
+    fixture.detectChanges();
+  }));
 
   it('should display a chip for each query filter', async(() => {
     fixture.detectChanges();
@@ -126,9 +144,10 @@ describe('HeaderComponent', () => {
   @Component({
     selector: 'jm-test-table-component',
     template:
-      `<jm-header></jm-header>`
+      `<jm-header [jobs]="jobs" [pageSize]="25"></jm-header>`
   })
   class TestHeaderComponent {
+    public jobs = new BehaviorSubject<JobListView>(initJobs);
     @ViewChild(HeaderComponent)
     public headerComponent: HeaderComponent;
   }

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -63,7 +63,7 @@ describe('HeaderComponent', () => {
         MatPaginatorModule,
         ReactiveFormsModule,
         RouterTestingModule.withRoutes([
-          {path: '', component: TestHeaderComponent}
+          {path: '', component: TestHeaderComponent},
           {path: 'jobs', component: TestHeaderComponent}
         ]),
       ]
@@ -126,7 +126,7 @@ describe('HeaderComponent', () => {
     testComponent.chips.set('statuses', 'list,of,statuses');
     testComponent.search();
     fixture.detectChanges();
-    fixture.whenStable(() => {
+    fixture.whenStable().then(() => {
       fixture.detectChanges();
       expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(0);
     });
@@ -136,7 +136,7 @@ describe('HeaderComponent', () => {
     testComponent.chips.delete('statuses');
     testComponent.search();
     fixture.detectChanges();
-    fixture.whenStable(() => {
+    fixture.whenStable().then(() => {
       fixture.detectChanges();
       expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(3);
     });

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -46,7 +46,7 @@ describe('HeaderComponent', () => {
   beforeEach(async(() => {
 
     TestBed.configureTestingModule({
-      declarations: [HeaderComponent, TestHeaderComponent],
+      declarations: [HeaderComponent, TestHeaderComponent, JoblessTestHeaderComponent],
       imports: [
         BrowserAnimationsModule,
         FormsModule,
@@ -171,14 +171,33 @@ describe('HeaderComponent', () => {
       .toContain('of 2');
   }));
 
+  it('should render properly on non-table views', async(() => {
+    fixture = TestBed.createComponent(JoblessTestHeaderComponent);
+    testComponent = fixture.componentInstance.headerComponent;
+    testComponent.chips = new Map().set('parent-id', 'Parent ID');
+    fixture.detectChanges();
+
+    // e.g. on the details page, should not see status tabs or pagination controls
+    expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(0);
+    expect(fixture.debugElement.queryAll(By.css('.mat-paginator')).length).toEqual(0);
+  }));
+
   @Component({
     selector: 'jm-test-table-component',
     template:
-      `<jm-header [jobs]="jobs" [pageSize]="25"></jm-header>`
+      `<jm-header [showControls]="true" [jobs]="jobs" [pageSize]="25"></jm-header>`
   })
   class TestHeaderComponent {
     public jobs = new BehaviorSubject<JobListView>(initJobs);
     @ViewChild(HeaderComponent)
     public headerComponent: HeaderComponent;
+  }
+
+  @Component({
+    selector: 'jm-test-table-component',
+    template: `<jm-header [showControls]="false"></jm-header>`
+  })
+  class JoblessTestHeaderComponent extends TestHeaderComponent {
+    public jobs = null;
   }
 });

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -64,6 +64,7 @@ describe('HeaderComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule.withRoutes([
           {path: '', component: TestHeaderComponent}
+          {path: 'jobs', component: TestHeaderComponent}
         ]),
       ]
     }).compileComponents();
@@ -80,7 +81,6 @@ describe('HeaderComponent', () => {
   }));
 
   it('should display a chip for each query filter', async(() => {
-    fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
     expect(de.queryAll(By.css('#chip')).length).toEqual(3);
   }));
@@ -123,14 +123,23 @@ describe('HeaderComponent', () => {
   }));
 
   it('should not show status buttons', async(() => {
+    testComponent.chips.set('statuses', 'list,of,statuses');
+    testComponent.search();
     fixture.detectChanges();
-    expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(3);
+    fixture.whenStable(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(0);
+    });
   }));
 
   it('should show status buttons', async(() => {
-    testComponent.chips.set('statuses', 'list,of,statuses');
+    testComponent.chips.delete('statuses');
+    testComponent.search();
     fixture.detectChanges();
-    expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(0);
+    fixture.whenStable(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(3);
+    });
   }));
 
   it('should change statuses', async(() => {
@@ -146,7 +155,7 @@ describe('HeaderComponent', () => {
     testComponent.jobs.next({
       results: [testJob1],
       exhaustive: false
-    );
+    });
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
     expect(de.query(By.css('.mat-paginator-range-label')).nativeElement.textContent)
@@ -156,7 +165,7 @@ describe('HeaderComponent', () => {
     testComponent.jobs.next({
       results: [testJob1, testJob2],
       exhaustive: true
-    );
+    });
     fixture.detectChanges();
     expect(de.query(By.css('.mat-paginator-range-label')).nativeElement.textContent)
       .toContain('of 2');

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -129,6 +129,7 @@ describe('HeaderComponent', () => {
 
   it('should show status buttons', async(() => {
     testComponent.chips.set('statuses', 'list,of,statuses');
+    fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(0);
   }));
 

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -142,6 +142,26 @@ describe('HeaderComponent', () => {
     expect(testComponent.selectedStatuses.length).toEqual(2);
   }));
 
+  it('should only show length for exhaustive job streams', async(() => {
+    testComponent.jobs.next({
+      results: [testJob1],
+      exhaustive: false
+    );
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    expect(de.query(By.css('.mat-paginator-range-label')).nativeElement.textContent)
+      .toContain('of many');
+
+    // Transition to exhaustive, "of X" should now display length.
+    testComponent.jobs.next({
+      results: [testJob1, testJob2],
+      exhaustive: true
+    );
+    fixture.detectChanges();
+    expect(de.query(By.css('.mat-paginator-range-label')).nativeElement.textContent)
+      .toContain('of 2');
+  }));
+
   @Component({
     selector: 'jm-test-table-component',
     template:

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -37,8 +37,9 @@ import {JobListView} from '../job-stream';
   styleUrls: ['./header.component.css'],
 })
 export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
-  // Pagination related controls will only be enabled if the following inputs
-  // are provided.
+  // Whether the status tabs and pagination controls are displayed. If true,
+  // jobs and pageSize must also be provided.
+  @Input() showControls: boolean = false;
   @Input() jobs: BehaviorSubject<JobListView>;
   @Input() pageSize: number;
   @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -228,8 +229,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   shouldDisplayStatusButtons(): boolean {
-    // jobs is only populated on multi-job views
-    return this.jobs && !URLSearchParamsUtils.unpackURLSearchParams(
+    return !URLSearchParamsUtils.unpackURLSearchParams(
       this.route.snapshot.queryParams['q'])[queryFields.statuses];
   }
 

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -80,11 +80,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this.chips.get(statusesCol)) {
       this.selectedStatuses = this.chips.get(statusesCol).split(',').map(k => JobStatus[k]);
     }
-    this.filterOptions();
     this.options = URLSearchParamsUtils.getQueryFields();
     if (environment.additionalColumns) {
       this.options = this.options.concat(environment.additionalColumns);
     }
+    this.filterOptions();
     this.pageSubscription = this.paginator.page.subscribe(this.pageSubject);
   }
 
@@ -144,9 +144,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   filterOptions(): void {
-    this.filteredOptions = this.control.valueChanges
-      .startWith(null)
-      .map(val => val ? this.filter(val) : this.options.slice());
+    this.filteredOptions = Observable.create((s) => {
+      s.next(this.options.slice());
+      this.control.valueChanges.subscribe(v => {
+        s.next(v === null ? this.options.slice() : this.filter(v));
+      });
+    });
   }
 
   getChipKeys(): string[] {

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -15,6 +15,7 @@ import {
   MatListModule,
   MatMenuModule,
   MatNativeDateModule,
+  MatPaginatorModule,
 } from "@angular/material";
 import {HeaderComponent} from "./header/header.component";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
@@ -33,6 +34,7 @@ import {FormsModule, ReactiveFormsModule} from "@angular/forms";
     MatListModule,
     MatMenuModule,
     MatNativeDateModule,
+    MatPaginatorModule,
     ReactiveFormsModule,
   ],
   declarations: [

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -25,7 +25,7 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /table\.component\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
 // Finally, start Karma to run the tests.

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -25,7 +25,7 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /table\.component\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
 // Finally, start Karma to run the tests.


### PR DESCRIPTION
- Refactor paginator from the table component, to the header; required restructuring the data flow between the job stream, data source, pagination control, table updates
- The job table no longer gets momentarily cleared out on navigation
- Refactor table to use the CDK model selection, including indeterminate state, e.g. if we have a mix of checked/unchecked -> select all now only selects the currently visible jobs
- Only show the aborted button if at least one selected job can be aborted
- Dropped the status tabs from the job details page (need to fully address the filter bar being there, but this was an easy incremental change to make in this PR)
- Move @types/angular to dev deps; it's odd that we need it at all since it just references Angular 1 stuff
