### PR TITLE
Remove job list header on details page

### DIFF
--- a/ui/src/app/job-details/job-details.component.html
+++ b/ui/src/app/job-details/job-details.component.html
@@ -1,4 +1,3 @@
-<jm-header [showControls]="false"></jm-header>
 <jm-panels [job]="job"></jm-panels>
 <!-- Only show the tasks table if there is at least 1 task. -->
 <jm-tasks *ngIf="hasTasks()" [tasks]="job.tasks" [jobId]="job.id"></jm-tasks>


### PR DESCRIPTION
This is my proposed solution to https://elastc.com/c/4pbVV8SQ/216-filter-bar-appears-on-job-details-page.

Looking at the header component, my judgement is that it isn't so much a general header as a job list header, and so does not belong on the job details page. If that is true, I'd suggest a follow-up PR to rename as such. I think it would be appropriate to create a separate header for the job details page if/when that seems like a good idea (e.g., to add a link back to the jobs list).