### PR TITLE
Fix initial non-exhaustive paginator rendering

### DIFF
--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -49,7 +49,7 @@ describe('JobListComponent', () => {
   let fixture: ComponentFixture<TestJobListComponent>;
   let fakeJobService: FakeJobManagerService;
 
-  beforeEach(async(() => {
+  beforeEach(fakeAsync(() => {
     fakeJobService = new FakeJobManagerService(testJobs(5));
 
     TestBed.configureTestingModule({
@@ -92,6 +92,9 @@ describe('JobListComponent', () => {
     router.navigate(['']);
     tick();
 
+    fixture.detectChanges();
+    tick();
+
     testComponent = fixture.debugElement.query(By.css('jm-job-list')).componentInstance;
   }));
 
@@ -112,14 +115,18 @@ describe('JobListComponent', () => {
     };
     testComponent.handleError(error);
     fixture.detectChanges();
+
     let de: DebugElement = fixture.debugElement;
     expect(de.query(By.css('.mat-simple-snackbar')).nativeElement.textContent)
       .toEqual("Bad Request (400): Missing required field `parentId` Dismiss");
   }));
 
+  // Note: Unfortunately many of the following fakeAsync() usages require
+  // gratuitous use of tick(). This is because a subcomponent of the paginator
+  // is setting a timeout on render.
   it('renders job rows', fakeAsync(() => {
-    tick();
     fixture.detectChanges();
+    tick();
 
     expectJobsRendered(fakeJobService.jobs.slice(0, 3));
   }));
@@ -128,9 +135,11 @@ describe('JobListComponent', () => {
     fakeJobService.jobs = testJobs(5);
     tick();
     fixture.detectChanges();
+    tick();
     const de: DebugElement = fixture.debugElement;
     de.query(By.css('.mat-paginator-increment')).nativeElement.click();
     fixture.detectChanges();
+    tick();
 
     // Page 2.
     expectJobsRendered(fakeJobService.jobs.slice(3, 5));
@@ -147,6 +156,7 @@ describe('JobListComponent', () => {
     // Back to page 1, which should have the first 3 jobs.
     de.query(By.css('.mat-paginator-decrement')).nativeElement.click();
     fixture.detectChanges();
+    tick();
     expectJobsRendered(fakeJobService.jobs.slice(0, 3));
   }));
 
@@ -162,6 +172,7 @@ describe('JobListComponent', () => {
     de.query(By.css('.completed-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
+    tick();
     expectJobsRendered([jobs[1], jobs[3]]);
   }));
 
@@ -183,6 +194,7 @@ describe('JobListComponent', () => {
     de.query(By.css('.group-abort')).nativeElement.click();
     tick();
     fixture.detectChanges();
+    tick();
 
     // Jobs 3 and 4 should be the only jobs displayed, as they are the only
     // remaining active jobs.
@@ -203,6 +215,7 @@ describe('JobListComponent', () => {
     de.query(By.css('.failed-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
+    tick();
     expectJobsRendered([jobs[3]]);
   }));
 

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -282,8 +282,8 @@ export class JobsPaginatorIntl extends MatPaginatorIntl {
               public changes: Subject<void>) {
     super();
     backendJobs.subscribe((jobList: JobListView) => {
-      // Ensure that the paginator component is redrawn on initialization and
-      // when the data changes, e.g. to catch the transition to exhaustive.
+      // Ensure that the paginator component is redrawn once we transition to an
+      // exhaustive list of jobs.
       if (jobList.exhaustive) {
         changes.next();
       }

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -276,11 +276,9 @@ export class JobsPaginatorIntl extends MatPaginatorIntl {
               public changes: Subject<void>) {
     super();
     backendJobs.subscribe((jobList: JobListView) => {
-      // Ensure that the paginator component is redrawn once we transition to
-      // an exhaustive list of jobs.
-      if (jobList.exhaustive) {
-        changes.next();
-      }
+      // Ensure that the paginator component is redrawn on initialization and
+      // when the data changes, e.g. to catch the transition to exhaustive.
+      changes.next();
     });
   }
 


### PR DESCRIPTION
The bug was that if you had a long list of jobs, the paginator would show "1-50 of 100" rather than "1-50 of many", until you interacted with the component, e.g. hover.

The cause of this issue is that `afterViewInit` gets run after the initial rendering. Modifying `_intl` also doesn't directly mutate anything that is rendered in the template, so ng doesn't pick up the update. Explicitly notifying the paginator of the change on initialization fixes this.