### PR TITLE
[UI] Use Angular Ahead of Time (AOT) compilation 

### DIFF
--- a/cromwell-compose-dev.yml
+++ b/cromwell-compose-dev.yml
@@ -4,7 +4,7 @@ services:
     extends:
       file: common-compose.yml
       service: ui
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_dev"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_dev", "--aot"]
   cromwell:
     build:
       context: .

--- a/cromwell-compose-staging.yml
+++ b/cromwell-compose-staging.yml
@@ -4,7 +4,7 @@ services:
     extends:
       file: common-compose.yml
       service: ui
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_staging"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_staging", "--aot"]
   cromwell:
     build:
       context: .

--- a/dsub-google-compose.yml
+++ b/dsub-google-compose.yml
@@ -7,7 +7,7 @@ services:
     # Use --host "ui" to match the container name, as this is how nginx will
     # access the UI on the network. This must match to avoid "Invalid Host"
     # errors. See also https://github.com/angular/angular-cli/issues/6349.
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=dsub_google"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=dsub_google", "--aot"]
   dsub:
     build:
       context: servers

--- a/dsub-local-compose.yml
+++ b/dsub-local-compose.yml
@@ -7,7 +7,7 @@ services:
     # Use --host "ui" to match the container name, as this is how nginx will
     # access the UI on the network. This must match to avoid "Invalid Host"
     # errors. See also https://github.com/angular/angular-cli/issues/6349.
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=dsub_local"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=dsub_local", "--aot"]
   dsub:
     build:
       context: servers


### PR DESCRIPTION
Based on information [here](https://angular.io/guide/aot-compiler) and [here](https://blog.nrwl.io/angular-is-aot-worth-it-8fa02eaf64d4), it seems that using ahead of time compilation for our angular app will speed up the development process. 

Ahead of time compilation compiles the typescript into javascript at build time rather than in the browser on each page refresh. This means that it takes *slightly* longer to build on code-changes, but the performance in the browser is significantly increased. The typescript needs to be compiled to run the webapp either way, I think this just ensures its compiled once per change in code, rather than in the browser every time you refresh. Finally, this results in fewer asynchronous request from the browser:
> The compiler inlines external HTML templates and CSS style sheets within the application JavaScript, eliminating separate ajax requests for those source files.

This has been causing issues for us because stacking up TCP request can causes future ones to be queued:
> The most common issue seen is a series of items that are queued or stalled. This indicates that too many resources are being retrieved from a single domain. On HTTP 1.0/1.1 connections, Chrome enforces a maximum of six TCP connections per host. If you are requesting twelve items at once, the first six will begin and the last half will be queued. Once one of the original half is finished, the first item in the queue will begin its request process.

This means some requests to our backend take much longer than expected because it get's queued until all of the ajax requests complete.