### PR TITLE
Add general loading + jobs table specific loading

### DIFF
--- a/ui/src/app/core/core.module.ts
+++ b/ui/src/app/core/core.module.ts
@@ -1,20 +1,33 @@
 import {NgModule, Optional, SkipSelf} from '@angular/core';
+import {MatSnackBarModule} from '@angular/material';
 
 import {CapabilitiesActivator} from "./capabilities-activator.service";
 import {CapabilitiesService} from "./capabilities.service";
 import {AuthService} from "./auth.service";
 import {JobManagerService} from './job-manager.service';
+import {NotifyLoadingService} from './notify-loading.service';
 
 /** Provides all of the common singleton components and services that can be
  *  shared across the app and should only ever be instantiated once. */
 @NgModule({
-  imports: [],
+  imports: [
+    MatSnackBarModule,
+  ],
   declarations: [],
   exports: [],
-  providers: [AuthService, CapabilitiesActivator, CapabilitiesService, JobManagerService]
+  providers: [
+    AuthService,
+    CapabilitiesActivator,
+    CapabilitiesService,
+    JobManagerService,
+    NotifyLoadingService
+  ]
 })
 export class CoreModule {
-  constructor( @Optional() @SkipSelf() parentModule: CoreModule) {
+  constructor(@Optional() @SkipSelf() parentModule: CoreModule,
+              notifyLoadingService: NotifyLoadingService) {
+    // Inject NotifyLoadingService to force eager instantiation, as no
+    // components depend on it. See https://github.com/dscheerens/ngx-eager-provider-loader/blob/master/eager-loading-in-angular-2.md
     this.throwIfAlreadyLoaded(parentModule, 'CoreModule');
   }
 

--- a/ui/src/app/core/notify-loading.service.ts
+++ b/ui/src/app/core/notify-loading.service.ts
@@ -1,10 +1,6 @@
 import {
-  Component,
-  ElementRef,
   Injectable,
   NgZone,
-  OnInit,
-  ViewChild,
 } from '@angular/core';
 import {
   Event as RouterEvent,
@@ -15,7 +11,6 @@ import {
   Router,
 } from '@angular/router';
 import {MatSnackBar, MatSnackBarRef, SimpleSnackBar} from '@angular/material';
-import {Observable} from 'rxjs/Observable';
 
 @Injectable()
 export class NotifyLoadingService {

--- a/ui/src/app/core/notify-loading.service.ts
+++ b/ui/src/app/core/notify-loading.service.ts
@@ -1,0 +1,57 @@
+import {
+  Component,
+  ElementRef,
+  Injectable,
+  NgZone,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+import {
+  Event as RouterEvent,
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
+  Router,
+} from '@angular/router';
+import {MatSnackBar, MatSnackBarRef, SimpleSnackBar} from '@angular/material';
+import {Observable} from 'rxjs/Observable';
+
+@Injectable()
+export class NotifyLoadingService {
+  private snackBarRef: MatSnackBarRef<SimpleSnackBar>;
+
+  constructor(
+    private zone: NgZone,
+    private snackBar: MatSnackBar,
+    router: Router,
+  ) {
+    router.events.subscribe((e: RouterEvent) => {
+      if (e instanceof NavigationStart) {
+        this.showSpinner();
+      } else if (e instanceof NavigationEnd
+                 || e instanceof NavigationError
+                 || e instanceof NavigationCancel) {
+        this.hideSpinner();
+      }
+    });
+  }
+
+  private showSpinner() {
+    this.zone.runOutsideAngular(() => {
+      if (this.snackBarRef) {
+        this.snackBarRef.dismiss();
+      }
+      this.snackBarRef = this.snackBar.open('Loading...');
+    });
+  }
+
+  private hideSpinner() {
+    this.zone.runOutsideAngular(() => {
+      if (this.snackBarRef) {
+        this.snackBarRef.dismiss();
+        this.snackBarRef = null;
+      }
+    });
+  }
+}

--- a/ui/src/app/job-list/job-list.component.css
+++ b/ui/src/app/job-list/job-list.component.css
@@ -1,0 +1,19 @@
+.table-container {
+  position: relative;
+}
+
+.spinner-overlay {
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+/* The pagination controls are near the top, so position relatively high. */
+.mat-spinner {
+  top: 15%;
+}

--- a/ui/src/app/job-list/job-list.component.css
+++ b/ui/src/app/job-list/job-list.component.css
@@ -2,8 +2,7 @@
   position: relative;
 }
 
-.spinner-overlay {
-  background: rgba(255, 255, 255, 0.7);
+.spinner-container {
   display: flex;
   justify-content: center;
   position: absolute;
@@ -11,6 +10,10 @@
   left: 0;
   height: 100%;
   width: 100%;
+}
+
+.job-list-table {
+  display: block;
 }
 
 /* The pagination controls are near the top, so position relatively high. */

--- a/ui/src/app/job-list/job-list.component.html
+++ b/ui/src/app/job-list/job-list.component.html
@@ -2,7 +2,12 @@
   [showControls]="true"
   [jobs]="jobs"
   [pageSize]="pageSize"></jm-header>
-<jm-job-list-table
-  [dataSource]="dataSource"
-  (onJobsChanged)="handleJobsChanged()">
-</jm-job-list-table>
+<div class="table-container">
+  <jm-job-list-table
+    [dataSource]="dataSource"
+    (onJobsChanged)="handleJobsChanged()">
+  </jm-job-list-table>
+  <div *ngIf="loading" class="spinner-overlay">
+    <mat-spinner></mat-spinner>
+  </div>
+</div>

--- a/ui/src/app/job-list/job-list.component.html
+++ b/ui/src/app/job-list/job-list.component.html
@@ -4,10 +4,12 @@
   [pageSize]="pageSize"></jm-header>
 <div class="table-container">
   <jm-job-list-table
+    class="job-list-table"
+    [ngStyle]="{'opacity': tableOpacity}"
     [dataSource]="dataSource"
     (onJobsChanged)="handleJobsChanged()">
   </jm-job-list-table>
-  <div *ngIf="loading" class="spinner-overlay">
+  <div *ngIf="loading" class="spinner-container">
     <mat-spinner></mat-spinner>
   </div>
 </div>

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -14,6 +14,7 @@ import {
   MatTooltipModule,
   MatCheckboxModule
 } from '@angular/material';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {CapabilitiesService} from '../core/capabilities.service';
@@ -79,12 +80,12 @@ describe('JobListComponent', () => {
         MatCheckboxModule,
         MatMenuModule,
         MatPaginatorModule,
+        MatProgressSpinnerModule,
         MatSnackBarModule,
         MatSortModule,
         MatTableModule,
         MatTooltipModule,
         RouterTestingModule.withRoutes([
-          {path: '', component: TestJobListComponent, resolve: {stream: JobListResolver}},
           {path: 'jobs', component: TestJobListComponent, resolve: {stream: JobListResolver}}
         ]),
         SharedModule
@@ -102,7 +103,7 @@ describe('JobListComponent', () => {
 
     const router: Router = TestBed.get(Router);
     router.initialNavigation();
-    router.navigate(['']);
+    router.navigate(['jobs']);
     tick();
 
     fixture.detectChanges();
@@ -142,6 +143,22 @@ describe('JobListComponent', () => {
     tick();
 
     expectJobsRendered(fakeJobService.jobs.slice(0, 3));
+  }));
+
+  it('renders the loading spinner only during load', fakeAsync(() => {
+    let de: DebugElement = fixture.debugElement;
+    expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(0);
+
+    // Ideally we'd click a nav element here instead, but unfortunately the
+    // navigate and job load would be evaluated within a single tick(), so we'd
+    // never see the loading spinner.
+    testComponent.reloadJobs('');
+    fixture.detectChanges();
+    expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(1);
+
+    tick();
+    fixture.detectChanges();
+    expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(0);
   }));
 
   it('paginates forward', fakeAsync(() => {

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -155,7 +155,11 @@ describe('JobListComponent', () => {
     testComponent.reloadJobs('');
     fixture.detectChanges();
     expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(1);
+    tick();
 
+    // We don't finish loading until we complete a query that matches the
+    // the ActiveRoute; so trigger a real navigate to clear the loading state.
+    de.query(By.css('.active-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
     expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(0);

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -147,14 +147,14 @@ describe('JobListComponent', () => {
 
   it('renders the loading spinner only during load', fakeAsync(() => {
     let de: DebugElement = fixture.debugElement;
-    expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(0);
+    expect(de.queryAll(By.css('.spinner-container')).length).toEqual(0);
 
     // Ideally we'd click a nav element here instead, but unfortunately the
     // navigate and job load would be evaluated within a single tick(), so we'd
     // never see the loading spinner.
     testComponent.reloadJobs('');
     fixture.detectChanges();
-    expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(1);
+    expect(de.queryAll(By.css('.spinner-container')).length).toEqual(1);
     tick();
 
     // We don't finish loading until we complete a query that matches the
@@ -162,7 +162,7 @@ describe('JobListComponent', () => {
     de.query(By.css('.active-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
-    expect(de.queryAll(By.css('.spinner-overlay')).length).toEqual(0);
+    expect(de.queryAll(By.css('.spinner-container')).length).toEqual(0);
   }));
 
   it('paginates forward', fakeAsync(() => {

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -89,6 +89,13 @@ export class JobListComponent implements OnInit {
     }
   }
 
+  get tableOpacity() {
+    if (this.loading) {
+      return .4;
+    }
+    return 1.0;
+  }
+
   handleError(error: any) {
     this.errorBar.open(
       new ErrorMessageFormatterPipe().transform(error),

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -75,6 +75,7 @@ export class JobListComponent implements OnInit {
           if (query !== this.route.snapshot.queryParams['q']) {
             // We initiated another query since the original request; ignore
             // the results of this old load.
+            // TODO(calbach): Track/cancel any ongoing requests.
             return;
           }
           // Only subscribe after the initial page load finishes, to avoid

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -33,6 +33,7 @@ export class JobListComponent implements OnInit {
     results: [],
     exhaustive: false
   });
+  loading = false;
   private jobStream: JobStream;
   private streamSubscription: Subscription;
 
@@ -65,6 +66,7 @@ export class JobListComponent implements OnInit {
 
   reloadJobs(query: string) {
     if (this.streamSubscription) {
+      this.loading = true;
       this.streamSubscription.unsubscribe();
       this.jobStream = new JobStream(this.jobManagerService,
           URLSearchParamsUtils.unpackURLSearchParams(query));
@@ -74,6 +76,7 @@ export class JobListComponent implements OnInit {
           // briefly loading an empty list of jobs.
           this.header.resetPagination();
           this.streamSubscription = this.jobStream.subscribe(this.jobs);
+          this.loading = false;
         })
         .catch(error => this.handleError(error));
     }

--- a/ui/src/app/job-list/job-list.module.ts
+++ b/ui/src/app/job-list/job-list.module.ts
@@ -10,6 +10,7 @@ import {
   MatTableModule,
   MatTooltipModule,
 } from '@angular/material';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 
@@ -26,6 +27,7 @@ import {SharedModule} from '../shared/shared.module';
     MatCheckboxModule,
     MatMenuModule,
     MatPaginatorModule,
+    MatProgressSpinnerModule,
     MatSnackBarModule,
     MatSortModule,
     MatTableModule,


### PR DESCRIPTION
- During all navigation, show an unobtrusive "Loading..." snackbar; this is a low-fidelity solution which doesn't cover the screen but provides user feedback that something is happening.
  - This primarily covers projects -> jobs list, jobs list -> job details transitions
- During job list reloads, show a mat-spinner + white transparent overlay on the table only; this behaves specially due to the following requirements:
  - In our ideal UX we'd like to leave the filter controls / query builder available during a query, e.g. if someone is typing in a series of chips, we don't want to block entry of the next chip on page load.
  - The job list component is special anyways, since its a singleton and navigation to itself doesn't block on data load
- Harden the jobs list towards multiple concurrent requests, which are easy to trigger with the query builder