### PR TITLE
[UI] Job details change inputs/outputs into table rather than drop downs

### DIFF
--- a/ui/src/app/job-details/job-details.module.ts
+++ b/ui/src/app/job-details/job-details.module.ts
@@ -11,6 +11,7 @@ import {
 
 import {JobDetailsComponent} from './job-details.component';
 import {JobPanelsComponent} from './panels/panels.component';
+import {ResourcesTableComponent} from './panels/resources-table/resources-table.component';
 import {SharedModule} from '../shared/shared.module';
 import {TaskDetailsComponent} from './tasks/tasks.component';
 
@@ -29,6 +30,7 @@ import {TaskDetailsComponent} from './tasks/tasks.component';
   declarations: [
     JobDetailsComponent,
     JobPanelsComponent,
+    ResourcesTableComponent,
     TaskDetailsComponent,
   ],
   providers: [],

--- a/ui/src/app/job-details/panels/panels.component.css
+++ b/ui/src/app/job-details/panels/panels.component.css
@@ -38,7 +38,11 @@ p {
 }
 
 .card.input-output {
-  width: 30;
+  width: 30%;
+}
+
+.mat-tab-labels{
+  justify-content: center;
 }
 
 .input-output-table {

--- a/ui/src/app/job-details/panels/panels.component.css
+++ b/ui/src/app/job-details/panels/panels.component.css
@@ -26,10 +26,21 @@ p {
   margin-right: 3rem;
 }
 
-.mat-card {
-  width: 25%;
+.card {
   margin-right: 1rem;
   margin-top: 2rem;
   float: left;
   min-height: 8.7rem;
+}
+
+.card.status {
+  width: 20%;
+}
+
+.card.input-output {
+  width: 30;
+}
+
+.input-output-table {
+  overflow: hidden;
 }

--- a/ui/src/app/job-details/panels/panels.component.html
+++ b/ui/src/app/job-details/panels/panels.component.html
@@ -30,15 +30,15 @@
 
   <mat-card class="card input-output" *ngIf="hasInputs() || hasOutputs()">
     <mat-card-title>
-      <mat-tab-group>
+      <mat-tab-group class="input-output-tabs">
 
-        <mat-tab md-center-tabs="true" *ngIf="hasInputs()" label="Inputs">
+        <mat-tab *ngIf="hasInputs()" label="Inputs">
           <mat-card-content>
             <jm-resources-table [entries]="job.inputs"></jm-resources-table>
           </mat-card-content>
         </mat-tab>
 
-        <mat-tab md-center-tabs="true" *ngIf="hasOutputs()" label="Outputs">
+        <mat-tab *ngIf="hasOutputs()" label="Outputs">
           <mat-card-content>
             <jm-resources-table [entries]="job.outputs"></jm-resources-table>
           </mat-card-content>

--- a/ui/src/app/job-details/panels/panels.component.html
+++ b/ui/src/app/job-details/panels/panels.component.html
@@ -10,7 +10,7 @@
       </span>
   </div>
 
-  <mat-card>
+  <mat-card class="card status">
     <mat-card-title>Status</mat-card-title>
     <mat-card-content>
       <p><b>
@@ -28,44 +28,23 @@
     </mat-card-content>
   </mat-card>
 
-  <mat-card>
-    <mat-card-title>Inputs and Outputs</mat-card-title>
-      <p *ngIf="showInputsButton()">
-        Input files
-        <button mat-button class="view-resources-button" [matMenuTriggerFor]="inputsMenu">
-          View
-        </button>
-      </p>
-      <mat-menu #inputsMenu="matMenu" class="wide-menu">
-        <a mat-menu-item *ngFor="let i of inputs" href="{{ getInputResourceURL(i) }}">
-          <span> {{ getInputResourceFileName(i) }}</span>
-        </a>
-      </mat-menu>
+  <mat-card class="card input-output" *ngIf="hasInputs() || hasOutputs()">
+    <mat-card-title>
+      <mat-tab-group>
 
-      <p *ngIf="showOutputsButton()">
-        Output files
-        <button mat-button class="view-resources-button" [matMenuTriggerFor]="outputsMenu">
-          View
-        </button>
-      </p>
-      <mat-menu #outputsMenu="matMenu" class="wide-menu">
-        <a mat-menu-item *ngFor="let o of outputs" href="{{ getOutputResourceURL(o) }}">
-          <span>{{ getOutputResourceFileName(o) }}</span>
-        </a>
-      </mat-menu>
+        <mat-tab md-center-tabs="true" *ngIf="hasInputs()" label="Inputs">
+          <mat-card-content>
+            <jm-resources-table [entries]="job.inputs"></jm-resources-table>
+          </mat-card-content>
+        </mat-tab>
 
-      <p *ngIf="showLogsButton()">
-        Log files
-        <button mat-button class="view-resources-button" [matMenuTriggerFor]="logsMenu">
-          View
-        </button>
-      </p>
-      <mat-menu #logsMenu="matMenu">
-        <a mat-menu-item *ngFor="let o of logs" href="{{ getLogResourceURL(o) }}">
-          <span>{{ o }}</span>
-        </a>
-      </mat-menu>
-    <mat-card-content>
-    </mat-card-content>
+        <mat-tab md-center-tabs="true" *ngIf="hasOutputs()" label="Outputs">
+          <mat-card-content>
+            <jm-resources-table [entries]="job.outputs"></jm-resources-table>
+          </mat-card-content>
+        </mat-tab>
+
+      </mat-tab-group>
+    </mat-card-title>
   </mat-card>
 </div>

--- a/ui/src/app/job-details/panels/panels.component.ts
+++ b/ui/src/app/job-details/panels/panels.component.ts
@@ -62,37 +62,21 @@ export class JobPanelsComponent implements OnChanges {
     }
   }
 
-  getInputResourceURL(key: string): string {
-    return ResourceUtils.getResourceBrowserURL(this.job.inputs[key]);
-  }
-
   getLogResourceURL(key: string): string {
     if (this.job.extensions) {
       return ResourceUtils.getResourceURL(this.job.extensions.logs[key]);
     }
   }
 
-  getOutputResourceURL(key: string): string {
-    return ResourceUtils.getResourceBrowserURL(this.job.outputs[key]);
+  hasInputs(): boolean {
+    return this.inputs && this.inputs.length > 0;
   }
 
-  getInputResourceFileName(key: string): string {
-    return key + ': ' + ResourceUtils.getResourceFileName(this.job.inputs[key]);
+  hasOutputs(): boolean {
+    return this.outputs && this.outputs.length > 0;
   }
 
-  getOutputResourceFileName(key: string): string {
-    return key + ': ' + ResourceUtils.getResourceFileName(this.job.outputs[key]);
-  }
-
-  showInputsButton(): boolean {
-    return this.inputs.length > 0;
-  }
-
-  showLogsButton(): boolean {
-    return this.logs.length > 0;
-  }
-
-  showOutputsButton(): boolean {
-    return this.outputs.length > 0;
+  hasLogs(): boolean {
+    return this.logs && this.logs.length > 0;
   }
 }

--- a/ui/src/app/job-details/panels/panels.component.ts
+++ b/ui/src/app/job-details/panels/panels.component.ts
@@ -2,7 +2,8 @@ import {
   Component,
   Input,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  ViewEncapsulation
 } from '@angular/core';
 
 import {JobMetadataResponse} from '../../shared/model/JobMetadataResponse';
@@ -14,6 +15,7 @@ import {ResourceUtils} from '../../shared/utils/resource-utils';
   selector: 'jm-panels',
   templateUrl: './panels.component.html',
   styleUrls: ['./panels.component.css'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class JobPanelsComponent implements OnChanges {
   // Whitelist of extended fields to display in the UI, in order.

--- a/ui/src/app/job-details/panels/resources-table/resources-table.component.html
+++ b/ui/src/app/job-details/panels/resources-table/resources-table.component.html
@@ -14,5 +14,5 @@
     </mat-cell>
   </ng-container>
 
-  <mat-row *matRowDef="let row; columns: resourcesColumns;"></mat-row>
+  <mat-row *matRowDef="let row; columns: ['key', 'value'];"></mat-row>
 </mat-table>

--- a/ui/src/app/job-details/panels/resources-table/resources-table.component.html
+++ b/ui/src/app/job-details/panels/resources-table/resources-table.component.html
@@ -1,0 +1,18 @@
+<mat-table class="resources-table" #table [dataSource]="entryKeys">
+  <ng-container matColumnDef="key">
+    <mat-cell *matCellDef="let key"> {{key}} </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="value">
+    <mat-cell *matCellDef="let key">
+      <a *ngIf="isResourceURL(key)" href="{{ getResourceURL(key) }}">
+        {{ getResourceFileName(key) }}
+      </a>
+      <span *ngIf="!isResourceURL(key)">
+        {{ entries[key] }}
+      </span>
+    </mat-cell>
+  </ng-container>
+
+  <mat-row *matRowDef="let row; columns: resourcesColumns;"></mat-row>
+</mat-table>

--- a/ui/src/app/job-details/panels/resources-table/resources-table.component.ts
+++ b/ui/src/app/job-details/panels/resources-table/resources-table.component.ts
@@ -1,0 +1,36 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
+import {ResourceUtils} from '../../../shared/utils/resource-utils';
+
+
+@Component({
+  selector: 'jm-resources-table',
+  templateUrl: './resources-table.component.html',
+  styleUrls: ['./resources-table.component.css'],
+})
+export class ResourcesTableComponent implements OnChanges {
+  private readonly resourcesColumns: string[] = ["key", "value"];
+
+  @Input() entries: Object;
+  entryKeys: Array<string>;
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.entryKeys = Object.keys(this.entries || {}).sort();
+  }
+
+  getResourceURL(key: string): string {
+    return ResourceUtils.getResourceBrowserURL(this.entries[key]);
+  }
+
+  getResourceFileName(key: string): string {
+    return ResourceUtils.getResourceFileName(this.entries[key]);
+  }
+
+  isResourceURL(key: string): boolean {
+    return ResourceUtils.isResourceURL(this.entries[key]);
+  }
+}

--- a/ui/src/app/job-details/panels/resources-table/resources-table.component.ts
+++ b/ui/src/app/job-details/panels/resources-table/resources-table.component.ts
@@ -13,7 +13,7 @@ import {ResourceUtils} from '../../../shared/utils/resource-utils';
   styleUrls: ['./resources-table.component.css'],
 })
 export class ResourcesTableComponent implements OnChanges {
-  private readonly resourcesColumns: string[] = ["key", "value"];
+  readonly resourcesColumns: string[] = ["key", "value"];
 
   @Input() entries: Object;
   entryKeys: Array<string>;

--- a/ui/src/app/shared/utils/resource-utils.spec.ts
+++ b/ui/src/app/shared/utils/resource-utils.spec.ts
@@ -6,7 +6,7 @@ describe('ResourceUtils', () => {
 
   it('should get resource browser URL', async(() => {
     expect(ResourceUtils.getResourceBrowserURL('gs://test-bucket/input.txt'))
-      .toEqual('https://console.cloud.google.com/storage/browser/test-bucket');
+      .toEqual('https://console.cloud.google.com/storage/browser/test-bucket?prefix=input.txt');
   }));
 
   it('should return invalid from invalid resource browser url', async(() => {

--- a/ui/src/app/shared/utils/resource-utils.ts
+++ b/ui/src/app/shared/utils/resource-utils.ts
@@ -3,19 +3,32 @@ export class ResourceUtils {
   static browserPrefix: string = "https://console.cloud.google.com/storage/browser/";
   static storagePrefix: string = "https://storage.cloud.google.com/";
 
+  /** Return boolean indicating if the value is a GCS url to a resource */
+  public static isResourceURL(value: string): boolean {
+    return !!ResourceUtils.validateGcsURLGetParts(value);
+  }
+
   /** Get link to a file's enclosing directory from its gcs url */
-  public static getResourceBrowserURL(uri: string): string {
-    let parts = ResourceUtils.validateGcsURLGetParts(uri);
+  public static getResourceBrowserURL(url: string): string {
+    let parts = ResourceUtils.validateGcsURLGetParts(url);
     // This excludes the object from the link to show the enclosing directory.
     // This is valid with wildcard glob (bucket/path/*) and directories
     // (bucket/path/dir/) as well, the * or empty string will be trimmed.
-    return parts ? ResourceUtils.browserPrefix + parts.slice(2,-1).join("/") : undefined;
+    var browserUrl = parts
+      ? ResourceUtils.browserPrefix + parts.slice(2,-1).join("/")
+      : undefined;
+    if (url.indexOf('*') == -1) {
+      browserUrl += "?prefix=" + ResourceUtils.getResourceFileName(url);
+    }
+    return browserUrl;
   }
 
   /** Get link to a file/folder from its gcs url */
-  public static getResourceURL(uri: string): string {
-    let parts = ResourceUtils.validateGcsURLGetParts(uri);
-    return parts ? ResourceUtils.storagePrefix + parts.slice(2).join("/") : undefined;
+  public static getResourceURL(url: string): string {
+    let parts = ResourceUtils.validateGcsURLGetParts(url);
+    return parts
+      ? ResourceUtils.storagePrefix + parts.slice(2).join("/")
+      : undefined;
   }
 
   /** Validate that the url is a gcs url and return the url parts */
@@ -32,14 +45,15 @@ export class ResourceUtils {
   }
 
   /** Parse file name from gs link */
-  public static getResourceFileName(value: string): string {
-    let parts = ResourceUtils.validateGcsURLGetParts(value);
-    let formattedValue = value;
-    if (parts && parts.length > 3 && parts[parts.length - 1]) {
+  public static getResourceFileName(url: string): string {
+    let parts = ResourceUtils.validateGcsURLGetParts(url);
+    let formattedValue = url;
+    if (parts && parts.length > 3 &&
+        parts[parts.length - 1] &&
+        parts[parts.length - 1].indexOf('*') == -1) {
       // display the file name instead of the full resourceURL
       formattedValue = parts[parts.length - 1];
     }
     return formattedValue;
   };
-
 }

--- a/ui/src/app/shared/utils/resource-utils.ts
+++ b/ui/src/app/shared/utils/resource-utils.ts
@@ -1,7 +1,7 @@
 /** Utilities for formatting links to folders/files on google cloud storage. */
 export class ResourceUtils {
-  static browserPrefix: string = "https://console.cloud.google.com/storage/browser/";
-  static storagePrefix: string = "https://storage.cloud.google.com/";
+  static browserPrefix: string = 'https://console.cloud.google.com/storage/browser/';
+  static storagePrefix: string = 'https://storage.cloud.google.com/';
 
   /** Return boolean indicating if the value is a GCS url to a resource */
   public static isResourceURL(value: string): boolean {
@@ -10,7 +10,7 @@ export class ResourceUtils {
 
   /** Get link to a file's enclosing directory from its gcs url */
   public static getResourceBrowserURL(url: string): string {
-    let parts = ResourceUtils.validateGcsURLGetParts(url);
+    const parts = ResourceUtils.validateGcsURLGetParts(url);
     // This excludes the object from the link to show the enclosing directory.
     // This is valid with wildcard glob (bucket/path/*) and directories
     // (bucket/path/dir/) as well, the * or empty string will be trimmed.
@@ -18,18 +18,18 @@ export class ResourceUtils {
       return undefined;
     }
 
-    var browserUrl = ResourceUtils.browserPrefix + parts.slice(2,-1).join("/");
+    var browserUrl = ResourceUtils.browserPrefix + parts.slice(2,-1).join('/');
     if (url.indexOf('*') == -1) {
-      browserUrl += "?prefix=" + ResourceUtils.getResourceFileName(url);
+      browserUrl += '?prefix=' + ResourceUtils.getResourceFileName(url);
     }
     return browserUrl;
   }
 
   /** Get link to a file/folder from its gcs url */
   public static getResourceURL(url: string): string {
-    let parts = ResourceUtils.validateGcsURLGetParts(url);
+    const parts = ResourceUtils.validateGcsURLGetParts(url);
     return parts
-      ? ResourceUtils.storagePrefix + parts.slice(2).join("/")
+      ? ResourceUtils.storagePrefix + parts.slice(2).join('/')
       : undefined;
   }
 
@@ -38,8 +38,8 @@ export class ResourceUtils {
     if (typeof(url) !== 'string') {
       return;
     }
-    let parts = url.split("/");
-    if (parts[0] != "gs:" || parts[1] != "") {
+    const parts = url.split('/');
+    if (parts[0] != 'gs:' || parts[1] != '') {
       // TODO(bryancrampton): Handle invalid resource URL gracefully
       return;
     }
@@ -48,7 +48,7 @@ export class ResourceUtils {
 
   /** Parse file name from gs link */
   public static getResourceFileName(url: string): string {
-    let parts = ResourceUtils.validateGcsURLGetParts(url);
+    const parts = ResourceUtils.validateGcsURLGetParts(url);
     let formattedValue = url;
     if (parts && parts.length > 3 &&
         parts[parts.length - 1] &&

--- a/ui/src/app/shared/utils/resource-utils.ts
+++ b/ui/src/app/shared/utils/resource-utils.ts
@@ -14,9 +14,11 @@ export class ResourceUtils {
     // This excludes the object from the link to show the enclosing directory.
     // This is valid with wildcard glob (bucket/path/*) and directories
     // (bucket/path/dir/) as well, the * or empty string will be trimmed.
-    var browserUrl = parts
-      ? ResourceUtils.browserPrefix + parts.slice(2,-1).join("/")
-      : undefined;
+    if (!parts) {
+      return undefined;
+    }
+
+    var browserUrl = ResourceUtils.browserPrefix + parts.slice(2,-1).join("/");
     if (url.indexOf('*') == -1) {
       browserUrl += "?prefix=" + ResourceUtils.getResourceFileName(url);
     }


### PR DESCRIPTION
Also adds some nice functionality for the input/output links to a GCS browser. Now, for non-wildcard paths, the filename will be embedded as a filter 'prefix' in the URL. This is useful when the directory on GCS has a lot of files, the link will now filter to the specific one you clicked on (plus any files which are prefixed with the filename, i.e. if you click `foo.bar` and `foo.bar.gz` exists in the bucket it will still show up).

Before merging this PR I will open another which adds the inlined logs/scripts, since this one removes logs from the details page completely. Also going to go over this with marty tomorrow.