### PR TITLE
Add status counters for exhaustive job lists

### DIFF
--- a/ui/src/app/shared/header/header.component.css
+++ b/ui/src/app/shared/header/header.component.css
@@ -17,7 +17,7 @@
 }
 
 .status-button {
-  width: 7rem;
+  min-width: 7rem;
   margin-right: .5rem;
 }
 

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -71,9 +71,15 @@
     <!-- Always include child divs, to support flex box style placement. -->
     <div>
       <ng-container *ngIf="shouldDisplayStatusButtons()">
-        <button mat-raised-button class="status-button active-button" (click)="showActiveJobs()">ACTIVE</button>
-        <button mat-raised-button class="status-button failed-button" (click)="showFailedJobs()">FAILED</button>
-        <button mat-raised-button class="status-button completed-button" (click)="showCompletedJobs()">COMPLETED</button>
+        <button mat-raised-button class="status-button active-button" (click)="showActiveJobs()">
+          Active <span *ngIf="shouldDisplayStatusCounts()">({{ getActiveCount() }})</span>
+        </button>
+        <button mat-raised-button class="status-button failed-button" (click)="showFailedJobs()">
+          Failed <span *ngIf="shouldDisplayStatusCounts()">({{ getFailedCount() }})</span>
+        </button>
+        <button mat-raised-button class="status-button completed-button" (click)="showCompletedJobs()">
+          Completed <span *ngIf="shouldDisplayStatusCounts()">({{ getCompletedCount() }})</span>
+        </button>
       </ng-container>
    </div>
 

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -44,16 +44,15 @@ describe('HeaderComponent', () => {
 
   let testComponent: HeaderComponent;
   let fixture: ComponentFixture<TestHeaderComponent>;
-  let capabilities: CapabilitiesResponse = 
-    {
-      displayFields: [
-        {field: 'status', display: 'Status'},
-        {field: 'submission', display: 'Submitted'},
-        {field: 'extensions.userId', display: 'User ID'},
-        {field: 'labels.job-id', display: 'Job ID'}
-      ],
-      queryExtensions: ['projectId']
-    };
+  let capabilities: CapabilitiesResponse = {
+    displayFields: [
+      {field: 'status', display: 'Status'},
+      {field: 'submission', display: 'Submitted'},
+      {field: 'extensions.userId', display: 'User ID'},
+      {field: 'labels.job-id', display: 'Job ID'}
+    ],
+    queryExtensions: ['projectId']
+  };
 
   beforeEach(async(() => {
 
@@ -154,6 +153,36 @@ describe('HeaderComponent', () => {
     fixture.whenStable().then(() => {
       fixture.detectChanges();
       expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(3);
+    });
+  }));
+
+  it('should show status counts', async(() => {
+    testComponent.chips.delete('statuses');
+    testComponent.jobs.next({
+      results: [testJob1, testJob2],
+      exhaustive: true
+    });
+    testComponent.search();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(
+        By.css('.active-button')).nativeElement.textContent).toContain('(2)');
+    });
+  }));
+
+  it('should show hide status counts on non-exhaustive', async(() => {
+    testComponent.chips.delete('statuses');
+    testComponent.jobs.next({
+      results: [testJob1, testJob2],
+      exhaustive: false
+    });
+    testComponent.search();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(
+        By.css('.active-button')).nativeElement.textContent).not.toContain('(2)');
     });
   }));
 

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -62,6 +62,10 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   filteredOptions: Observable<string[]>;
 
+  private readonly activeStatuses = [JobStatus.Submitted, JobStatus.Running, JobStatus.Aborting];
+  private readonly completedStatuses = [JobStatus.Succeeded, JobStatus.Aborted];
+  private readonly failedStatuses = [JobStatus.Failed];
+
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
@@ -248,16 +252,36 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.route.snapshot.queryParams['q'])['statuses'];
   }
 
+  shouldDisplayStatusCounts(): boolean {
+    // Only show status counts if all jobs are loaded client-side.
+    return this.jobs.value.exhaustive;
+  }
+
   showActiveJobs(): void {
-    this.navigateWithStatus([JobStatus.Submitted, JobStatus.Running, JobStatus.Aborting])
+    this.navigateWithStatus(this.activeStatuses.slice())
   }
 
   showCompletedJobs(): void {
-    this.navigateWithStatus([JobStatus.Succeeded, JobStatus.Aborted]);
+    this.navigateWithStatus(this.completedStatuses.slice())
   }
 
   showFailedJobs(): void {
-    this.navigateWithStatus([JobStatus.Failed]);
+    this.navigateWithStatus(this.failedStatuses.slice());
+  }
+
+  getActiveCount(): number {
+    return this.jobs.value.results.filter(
+      j => this.activeStatuses.includes(j.status)).length;
+  }
+
+  getFailedCount(): number {
+    return this.jobs.value.results.filter(
+      j => this.failedStatuses.includes(j.status)).length;
+  }
+
+  getCompletedCount(): number {
+    return this.jobs.value.results.filter(
+      j => this.completedStatuses.includes(j.status)).length;
   }
 
   private refreshChips(query: string): void {


### PR DESCRIPTION
Simply hide the status counters if we have a non-exhaustive job stream. This may lead to slightly confusing behavior, but will help in a subset of cases.

A few ideas for future improvements:
1. Get a "total" count in ListOperations, thereby bypassing a need to materialize the full job list to populate these values.
2. Load a larger initial page; once we have a total count in ListOperations, we would also decide whether to load the full job list client side, depending on he total size of the stream.
3. Give an option to load everything client side. Possibly clicking "many" would yield a drop-down to load all?
4. Have a placeholder for non-exhaustive streams, with some helper text when you mouseover (and perhaps an option to load all).