### PR TITLE
[Cromwell] Fix the statuses of Cromwell tasks

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -14,9 +14,8 @@ from jobs.models.task_metadata import TaskMetadata
 from jobs.models.failure_message import FailureMessage
 from jobs.models.update_job_labels_response import UpdateJobLabelsResponse
 from jobs.models.update_job_labels_request import UpdateJobLabelsRequest
+from jobs.controllers.utils import task_statuses
 
-CROMWELL_DONE_STATUS = 'Done'
-API_SUCCESS_STATUS = 'Succeeded'
 _DEFAULT_PAGE_SIZE = 64
 
 
@@ -128,7 +127,7 @@ def format_task(task_name, task_metadata):
     return TaskMetadata(
         name=remove_workflow_name(task_name),
         execution_id=task_metadata.get('jobId'),
-        execution_status=cromwell_to_api_status(
+        execution_status=task_statuses.cromwell_execution_to_api(
             task_metadata.get('executionStatus')),
         start=_parse_datetime(task_metadata.get('start')),
         end=_parse_datetime(task_metadata.get('end')),
@@ -138,13 +137,6 @@ def format_task(task_name, task_metadata):
         return_code=task_metadata.get('returnCode'),
         attempts=task_metadata.get('attempt'),
         job_id=task_metadata.get('subWorkflowId'))
-
-
-def cromwell_to_api_status(status):
-    """ Use the API status 'Succeeded' instead of 'Done' for completed cromwell tasks. """
-    if status == CROMWELL_DONE_STATUS:
-        return API_SUCCESS_STATUS
-    return status
 
 
 def remove_workflow_name(name):

--- a/servers/cromwell/jobs/controllers/utils/task_statuses.py
+++ b/servers/cromwell/jobs/controllers/utils/task_statuses.py
@@ -1,6 +1,5 @@
 from jobs.common import enum
 
-
 # The execution statuses of Cromwell are defined here:
 # https://github.com/broadinstitute/cromwell/blob/710c1931a6745a187ffd026f2cdafea2ffaaf2dc/core/src/main/scala/cromwell/core/ExecutionStatus.scala#L5
 # It provided a reasonable mapping in this file, but may need to be changed in the future on demand
@@ -48,6 +47,6 @@ def cromwell_execution_to_api(execution_status):
     :return: Api status 'Submitted', 'Running', 'Aborting', 'Failed', 'Succeeded', or 'Aborted'
     """
     if execution_status not in CROMWELL_EXECUTION_STATUS_MAP:
-        raise ValueError('Unrecognized Cromwell execution status: {}'.format(execution_status))
+        raise ValueError('Unrecognized Cromwell execution status: {}'.format(
+            execution_status))
     return CROMWELL_EXECUTION_STATUS_MAP[execution_status]
-

--- a/servers/cromwell/jobs/controllers/utils/task_statuses.py
+++ b/servers/cromwell/jobs/controllers/utils/task_statuses.py
@@ -1,0 +1,53 @@
+from jobs.common import enum
+
+
+# The execution statuses of Cromwell are defined here:
+# https://github.com/broadinstitute/cromwell/blob/710c1931a6745a187ffd026f2cdafea2ffaaf2dc/core/src/main/scala/cromwell/core/ExecutionStatus.scala#L5
+# It provided a reasonable mapping in this file, but may need to be changed in the future on demand
+
+ApiStatus = enum(
+    SUBMITTED='Submitted',
+    RUNNING='Running',
+    ABORTING='Aborting',
+    ABORTED='Aborted',
+    SUCCEEDED='Succeeded',
+    FAILED='Failed')
+CromwellExecutionStatus = enum(
+    NOTSTARTED='NotStarted',
+    QUEUEDINCROMWELL='QueuedInCromwell',
+    STARTING='Starting',
+    RUNNING='Running',
+    ABORTING='Aborting',
+    UNSTARTABLE='Unstartable',
+    ABORTED='Aborted',
+    BYPASSED='Bypassed',
+    RETRYABLEFAILURE='RetryableFailure',
+    FAILED='Failed',
+    DONE='Done')
+
+CROMWELL_EXECUTION_STATUS_MAP = {
+    CromwellExecutionStatus.NOTSTARTED: ApiStatus.SUBMITTED,
+    CromwellExecutionStatus.QUEUEDINCROMWELL: ApiStatus.SUBMITTED,
+    CromwellExecutionStatus.STARTING: ApiStatus.SUBMITTED,
+    CromwellExecutionStatus.RUNNING: ApiStatus.RUNNING,
+    CromwellExecutionStatus.ABORTING: ApiStatus.ABORTING,
+    CromwellExecutionStatus.UNSTARTABLE: ApiStatus.FAILED,
+    CromwellExecutionStatus.ABORTED: ApiStatus.ABORTED,
+    CromwellExecutionStatus.BYPASSED: ApiStatus.SUBMITTED,
+    CromwellExecutionStatus.RETRYABLEFAILURE: ApiStatus.RUNNING,
+    CromwellExecutionStatus.FAILED: ApiStatus.FAILED,
+    CromwellExecutionStatus.DONE: ApiStatus.SUCCEEDED
+}
+
+
+def cromwell_execution_to_api(execution_status):
+    """ Map a Cromwell execution status to an API status.
+
+    :param str execution_status: 'NotStarted', 'QueuedInCromwell', 'Starting', 'Running', 'Aborting', 'Failed',
+     'RetryableFailure', 'Done', 'Bypassed', 'Aborted', or 'Unstartable'
+    :return: Api status 'Submitted', 'Running', 'Aborting', 'Failed', 'Succeeded', or 'Aborted'
+    """
+    if execution_status not in CROMWELL_EXECUTION_STATUS_MAP:
+        raise ValueError('Unrecognized Cromwell execution status: {}'.format(execution_status))
+    return CROMWELL_EXECUTION_STATUS_MAP[execution_status]
+

--- a/servers/dsub/jobs/controllers/utils/job_statuses.py
+++ b/servers/dsub/jobs/controllers/utils/job_statuses.py
@@ -38,7 +38,7 @@ DSUB_STATUS_MAP = {
 
 
 def dsub_to_api(job):
-    """Map an API status to a dsub status
+    """Map a dsub status to an API status
 
         Args:
             dsub_status (str): 'RUNNING', 'CANCELED', 'SUCCESS', or 'FAILURE'
@@ -58,7 +58,7 @@ def dsub_to_api(job):
 
 
 def api_to_dsub(api_status):
-    """Map a dsub status to an API status
+    """Map an API status to a dsub status
 
         Args:
             api_status (str): 'Submitted', 'Running', 'Aborting', 'Aborted',


### PR DESCRIPTION
Fix the broken statuses of Cromwell task by mapping those atomic execution statuses to Job Manager's common API statuses. 

This PR avoids adding any detailed execution statuses to the capabilities endpoint for simplicity. Besides, some of the Cromwell execution statuses, for example, `Bypassed` or `RetryableFailure` are really rare and it doesn't make any sense to expose them to users. 

There are some discussions here: https://github.com/broadinstitute/cromwell/issues/3328