### PR TITLE
Add support for cromwell-as-a-service

### DIFF
--- a/cromwell-compose-caas.yml
+++ b/cromwell-compose-caas.yml
@@ -4,7 +4,7 @@ services:
     extends:
       file: common-compose.yml
       service: ui
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_staging"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_caas"]
   cromwell:
     build:
       context: .
@@ -13,7 +13,8 @@ services:
       file: common-compose.yml
       service: cromwell
     environment:
-      - USE_CAAS=False
+      - CROMWELL_URL=${CROMWELL_URL:-https://cromwell.caas-dev.broadinstitute.org/api/workflows/v1}
+      - USE_CAAS=True
   jobs-proxy:
     extends:
       file: common-compose.yml

--- a/cromwell-compose-dev.yml
+++ b/cromwell-compose-dev.yml
@@ -12,6 +12,8 @@ services:
     extends:
       file: common-compose.yml
       service: cromwell
+    environment:
+      - USE_CAAS=False
   jobs-proxy:
     extends:
       file: common-compose.yml

--- a/servers/cromwell/jobs/__main__.py
+++ b/servers/cromwell/jobs/__main__.py
@@ -60,7 +60,7 @@ finally:
     app.app.config.update(config)
 
 app.app.config['cromwell_url'] = args.cromwell_url
-app.app.config['use_caas'] = args.use_caas.lower() == 'true'
+app.app.config['use_caas'] = args.use_caas and args.use_caas.lower() == 'true'
 app.app.json_encoder = JSONEncoder
 app.add_api('swagger.yaml', base_path=args.path_prefix)
 

--- a/servers/cromwell/jobs/__main__.py
+++ b/servers/cromwell/jobs/__main__.py
@@ -19,6 +19,11 @@ parser.add_argument(
     help='Url for fetching data from cromwell',
     default=os.environ.get('CROMWELL_URL'))
 parser.add_argument(
+    '--use_caas',
+    type=str,
+    help='Whether the cromwell backend is using cromwell-as-a-service',
+    default=os.environ.get('USE_CAAS'))
+parser.add_argument(
     '--path_prefix',
     type=str,
     help='Path prefix, e.g. /api/v1, to serve from',
@@ -55,26 +60,28 @@ finally:
     app.app.config.update(config)
 
 app.app.config['cromwell_url'] = args.cromwell_url
+app.app.config['use_caas'] = args.use_caas.lower() == 'true'
 app.app.json_encoder = JSONEncoder
 app.add_api('swagger.yaml', base_path=args.path_prefix)
 
 
 def run():
     # Check the connections with cromwell
-    try:
-        response = requests.head(
-            args.cromwell_url,
-            auth=HTTPBasicAuth(app.app.config['cromwell_user'],
-                               app.app.config['cromwell_password']),
-            timeout=5)
-        if response.status_code == 401:
-            raise requests.exceptions.HTTPError(
-                'Invalid credentials for the Cromwell: {}'.format(
-                    args.cromwell_url))
-        return app.app
-    except KeyError:
-        logger.error('Invalid config.json file provided.')
-    except requests.exceptions.RequestException as err:
-        logger.critical(err)
-        logger.critical('Failed to connect to Cromwell: {}'.format(
-            args.cromwell_url))
+    if not app.app.config['use_caas']:
+        try:
+            response = requests.head(
+                args.cromwell_url,
+                auth=HTTPBasicAuth(app.app.config['cromwell_user'],
+                                   app.app.config['cromwell_password']),
+                timeout=5)
+            if response.status_code == 401:
+                raise requests.exceptions.HTTPError(
+                    'Invalid credentials for the Cromwell: {}'.format(
+                        args.cromwell_url))
+        except KeyError:
+            logger.error('Invalid config.json file provided.')
+        except requests.exceptions.RequestException as err:
+            logger.critical(err)
+            logger.critical('Failed to connect to Cromwell: {}'.format(
+                args.cromwell_url))
+    return app.app

--- a/servers/cromwell/jobs/controllers/capabilities_controller.py
+++ b/servers/cromwell/jobs/controllers/capabilities_controller.py
@@ -1,3 +1,5 @@
+from flask import current_app
+from jobs.models.authentication_capability import AuthenticationCapability
 from jobs.models.capabilities_response import CapabilitiesResponse
 from jobs.models.display_field import DisplayField
 
@@ -8,7 +10,7 @@ def get_capabilities():
     Returns:
         CapabilitiesResponse: Response containing this backend's capabilities
     """
-    return CapabilitiesResponse(
+    capabilities = CapabilitiesResponse(
         display_fields=[
             DisplayField(field='status', display='Status'),
             DisplayField(field='submission', display='Submitted'),
@@ -23,3 +25,11 @@ def get_capabilities():
             'cromwell-workflow-name', 'cromwell-workflow-id', 'comment'
         ],
         query_extensions=[])
+    if current_app.config['use_caas']:
+        capabilities.authentication = AuthenticationCapability(
+            is_required=True,
+            scopes=[
+                'https://www.googleapis.com/auth/userinfo.profile',
+                'https://www.googleapis.com/auth/userinfo.email'
+            ])
+    return capabilities

--- a/servers/cromwell/jobs/controllers/utils/auth.py
+++ b/servers/cromwell/jobs/controllers/utils/auth.py
@@ -1,0 +1,29 @@
+from flask import current_app, request
+from requests.auth import HTTPBasicAuth
+from werkzeug.exceptions import Unauthorized
+
+
+def requires_auth(fn):
+    def wrapper(*args, **kwargs):
+        auth_token = request.headers.get('Authentication')
+        auth = _get_user_auth() if not auth_token else None
+        headers = _get_auth_header(auth_token)
+        if not auth_token and not auth:
+            raise Unauthorized('User not authorized to access this resource.')
+        kwargs['auth'] = auth
+        kwargs['auth_token'] = auth_token
+        kwargs['auth_headers'] = headers
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def _get_user_auth():
+    return HTTPBasicAuth(current_app.config['cromwell_user'],
+                         current_app.config['cromwell_password'])
+
+
+def _get_auth_header(auth_token):
+    return {
+        "Authorization": str(auth_token)
+    } if current_app.config['use_caas'] and auth_token else None

--- a/servers/cromwell/jobs/controllers/utils/auth.py
+++ b/servers/cromwell/jobs/controllers/utils/auth.py
@@ -24,8 +24,6 @@ def _get_user_auth():
 def _get_auth_header(auth_token):
     if current_app.config['use_caas']:
         if auth_token:
-            return {
-                "Authorization": str(auth_token)
-            }
+            return {"Authorization": str(auth_token)}
         else:
             raise Unauthorized('User not authorized to access this resource.')

--- a/servers/cromwell/jobs/test/test_auth_utils.py
+++ b/servers/cromwell/jobs/test/test_auth_utils.py
@@ -6,7 +6,6 @@ from . import BaseTestCase
 
 
 class TestAuthUtils(BaseTestCase):
-
     def setUp(self):
         self.base_url = 'https://test-cromwell.org'
 

--- a/servers/cromwell/jobs/test/test_auth_utils.py
+++ b/servers/cromwell/jobs/test/test_auth_utils.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+import requests_mock
+from . import BaseTestCase
+
+
+class TestAuthUtils(BaseTestCase):
+
+    def setUp(self):
+        self.base_url = 'https://test-cromwell.org'
+
+    @requests_mock.mock()
+    def test_token_auth_returns_200(self, mock_request):
+        self.app.config.update({
+            'cromwell_url': self.base_url,
+            'cromwell_user': '',
+            'cromwell_password': '',
+            'use_caas': True
+        })
+
+        def _request_callback(request, context):
+            context.status_code = 200
+            return {'results': [], 'totalResultsCount': 0}
+
+        query_url = self.base_url + '/query'
+        mock_request.post(query_url, json=_request_callback)
+
+        response = self.client.open(
+            '/jobs/query',
+            method='POST',
+            headers={'Authentication': 'Bearer 12345'},
+            data={},
+            content_type='application/json')
+        self.assertStatus(response, 200)
+
+    @requests_mock.mock()
+    def test_basic_auth_returns_200(self, mock_request):
+        self.app.config.update({
+            'cromwell_url': self.base_url,
+            'cromwell_user': 'user',
+            'cromwell_password': 'password',
+            'use_caas': False
+        })
+
+        def _request_callback(request, context):
+            context.status_code = 200
+            return {'results': [], 'totalResultsCount': 0}
+
+        query_url = self.base_url + '/query'
+        mock_request.post(query_url, json=_request_callback)
+
+        response = self.client.open(
+            '/jobs/query',
+            method='POST',
+            data={},
+            content_type='application/json')
+        self.assertStatus(response, 200)
+
+    def test_no_auth_with_caas_returns_401(self):
+        self.app.config.update({
+            'cromwell_url': self.base_url,
+            'cromwell_user': '',
+            'cromwell_password': '',
+            'use_caas': True
+        })
+        response = self.client.open(
+            '/jobs/query',
+            method='POST',
+            data={},
+            content_type='application/json')
+        self.assertStatus(response, 401)
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -23,7 +23,8 @@ class TestJobsController(BaseTestCase):
         self.app.config.update({
             'cromwell_url': self.base_url,
             'cromwell_user': 'user',
-            'cromwell_password': 'password'
+            'cromwell_password': 'password',
+            'use_caas': False
         })
 
     @requests_mock.mock()

--- a/ui/.angular-cli.json
+++ b/ui/.angular-cli.json
@@ -29,7 +29,8 @@
         "dsub_google": "environments/environment.dsub.google.ts",
         "dsub_local": "environments/environment.dsub.local.ts",
         "cromwell_dev": "environments/environment.cromwell.dev.ts",
-        "cromwell_staging": "environments/environment.cromwell.staging.ts"
+        "cromwell_staging": "environments/environment.cromwell.staging.ts",
+        "cromwell_caas": "environments/environment.cromwell.caas.ts"
       }
     }
   ],

--- a/ui/src/environments/environment.cromwell.caas.ts
+++ b/ui/src/environments/environment.cromwell.caas.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  apiUrl: '/api/v1',
+  clientId: '619310558212-u9uso7pdgh7s6r6gqfrs1tm58abdqtf2.apps.googleusercontent.com',
+  production: false,
+};


### PR DESCRIPTION
Support making API requests to cromwell-as-a-service using a bearer token (requires google sign in to be enabled).