### PR TITLE
[Cromwell] Fix the cannot find application issue

### DIFF
--- a/servers/cromwell/jobs/__init__.py
+++ b/servers/cromwell/jobs/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+from __main__ import run


### PR DESCRIPTION
Fix the cannot find application issue by adding back the import statement, which is necessary for gunicorn to find the application.