### PR TITLE
[UI] Auto select top project on drop down

### DIFF
--- a/ui/src/app/projects/projects.component.html
+++ b/ui/src/app/projects/projects.component.html
@@ -7,7 +7,9 @@
              placeholder="Project ID"
              [matAutocomplete]="auto"
              [formControl]="projectsControl">
-      <mat-autocomplete #auto="matAutocomplete" (optionSelected)="navigateJobs()">
+      <mat-autocomplete #auto="matAutocomplete"
+                        [autoActiveFirstOption]=true
+                        (optionSelected)="navigateJobs()">
         <mat-option *ngFor="let project of projectsObservable | async" [value]="project">
           <span><div class="project-id">{{ project }}</div></span>
         </mat-option>

--- a/ui/src/app/projects/projects.component.ts
+++ b/ui/src/app/projects/projects.component.ts
@@ -78,7 +78,9 @@ export class ProjectsComponent implements OnInit {
     this.projectsObservable = Observable.fromPromise(
       this.projectsService.listProjects(filter)
         .then(listView => {
-          this.projects = listView.results.sort() ? listView.results : [];
+          // Sort projects alphabetically so that the shorter, matching project
+          // shows up first.
+          this.projects = (listView ? listView.results : []).sort();
           // If the currently entered string is a valid project ID, hide the
           // autocomplete menu so that the user can click the button
           this.viewJobsEnabled = this.validProject(this.projectsControl.value)

--- a/ui/src/app/projects/projects.component.ts
+++ b/ui/src/app/projects/projects.component.ts
@@ -26,7 +26,6 @@ import {URLSearchParamsUtils} from "../shared/utils/url-search-params.utils";
   styleUrls: ['./projects.component.css'],
 })
 export class ProjectsComponent implements OnInit {
-  @ViewChild('auto') auto: ElementRef;
   projectsControl: FormControl;
   projectsObservable: Observable<void|any[]>;
   projects: any[];
@@ -79,13 +78,14 @@ export class ProjectsComponent implements OnInit {
     this.projectsObservable = Observable.fromPromise(
       this.projectsService.listProjects(filter)
         .then(listView => {
-          this.projects = listView.results ? listView.results : [];
+          this.projects = listView.results.sort() ? listView.results : [];
           // If the currently entered string is a valid project ID, hide the
           // autocomplete menu so that the user can click the button
           this.viewJobsEnabled = this.validProject(this.projectsControl.value)
             || !listView.exhaustive;
           return !this.viewJobsEnabled || this.projects.length > 1 ?
-            this.projects.map(project => project.projectId) : [];})
+            this.projects.map(project => project.projectId).sort() : [];
+        })
         .catch(response => this.handleError(response))
     );
   }


### PR DESCRIPTION
Also add sorting to the projects list. This is necessary in the case where you have two projects with one name being the prefix of the other (ex: `bvdp-jmui-testing` and `bvdp-jmui-testing-2`). We'd like the shorter to be first so that if you type exactly `bvdp-jmui-testing` the exact match is auto-selected.