### PR TITLE
Fix table width sizing and long field truncation

### DIFF
--- a/ui/src/app/job-list/job-list.component.css
+++ b/ui/src/app/job-list/job-list.component.css
@@ -2,7 +2,6 @@
   position: relative;
   overflow: scroll;
   width: 100%;
-  height: 100%;
 }
 
 .spinner-container {

--- a/ui/src/app/job-list/job-list.component.css
+++ b/ui/src/app/job-list/job-list.component.css
@@ -1,5 +1,8 @@
 .table-container {
   position: relative;
+  overflow: scroll;
+  width: 100%;
+  height: 100%;
 }
 
 .spinner-container {
@@ -13,7 +16,8 @@
 }
 
 .job-list-table {
-  display: block;
+  display: inline-block;
+  width: 100%;
 }
 
 /* The pagination controls are near the top, so position relatively high. */

--- a/ui/src/app/job-list/table/table.component.css
+++ b/ui/src/app/job-list/table/table.component.css
@@ -1,9 +1,5 @@
 /* Job Manager table */
 
-.job-details-button {
-  color: black;
-}
-
 .mat-table {
   display: table;
   width: 100%;
@@ -21,10 +17,18 @@
   vertical-align: middle;
   padding: 0 8px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  max-width: 40rem;
+  white-space: nowrap;
+}
+
+.checkbox-column {
+  min-width: 10rem;
+}
+
+.display-field {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 20rem;
 }
 
 .mat-column-select {
@@ -49,6 +53,7 @@
   text-align: center;
   float: left;
   cursor: pointer;
+  color: black;
 }
 
 /* Job details dropdown */

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -2,7 +2,7 @@
 
   <!-- Job name column -->
   <ng-container matColumnDef="Job">
-    <mat-header-cell *matHeaderCellDef>
+    <mat-header-cell class="checkbox-column" *matHeaderCellDef>
       <mat-checkbox class = "checkbox"
                     (change)="$event ? toggleSelectAll() : null"
                     [checked]="allSelected()"
@@ -10,7 +10,7 @@
       </mat-checkbox>
       Job
     </mat-header-cell>
-    <mat-cell *matCellDef="let j">
+    <mat-cell class="checkbox-column" *matCellDef="let j">
       <mat-checkbox class = "checkbox"
                     (click)="$event.stopPropagation()"
                     (change)="$event ? selection.toggle(j) : null"
@@ -57,7 +57,7 @@
     <ng-container matColumnDef="{{ df.field }}">
       <mat-header-cell *matHeaderCellDef>{{ df.display }}</mat-header-cell>
       <mat-cell class="additional-column" *matCellDef="let j">
-        <div *ngIf=!isStatusField(df)>{{ getFieldValue(j, df) }}</div>
+        <div class="display-field" *ngIf=!isStatusField(df)>{{ getFieldValue(j, df) }}</div>
         <button mat-icon-button disabled *ngIf=isStatusField(df)>
           <img matTooltip="{{ getFieldValue(j, df) }}" matTooltipPosition="before"
              src="{{ getStatusUrl(getFieldValue(j, df)) }}">


### PR DESCRIPTION
Make the job list table horizontally scrollable within the page. Fixes the bug where the query builder is cut off when there are too many columns in the table (overflow list tables). Also fixes the bug where the checkbox and job name appeared stacked on top of each other.

This is a precursor to pin selected-jobs controls to window bottom which I will follow up with in a separate PR.