### PR TITLE
[UI] Separate job name and checkbox columns

### DIFF
--- a/ui/src/app/job-list/table/table.component.css
+++ b/ui/src/app/job-list/table/table.component.css
@@ -21,10 +21,6 @@
   white-space: nowrap;
 }
 
-.checkbox-column {
-  min-width: 10rem;
-}
-
 .display-field {
   white-space: nowrap;
   overflow: hidden;
@@ -57,9 +53,13 @@
 }
 
 /* Job details dropdown */
+.details-drop-down-cell {
+  max-width: 2rem;
+}
+
 .jobs-dropdown-arrow {
   visibility: hidden;
-  float: right;
+  float: left;
   margin-right: 4rem;
   display: inline-block;
 }

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -1,29 +1,39 @@
 <mat-table #table [dataSource]="dataSource">
 
-  <!-- Job name column -->
-  <ng-container matColumnDef="Job">
-    <mat-header-cell class="checkbox-column" *matHeaderCellDef>
+  <!-- Checkbox column -->
+  <ng-container matColumnDef="Checkbox">
+    <mat-header-cell *matHeaderCellDef>
       <mat-checkbox class = "checkbox"
                     (change)="$event ? toggleSelectAll() : null"
                     [checked]="allSelected()"
                     [indeterminate]="partiallySelected()">
       </mat-checkbox>
-      Job
     </mat-header-cell>
-    <mat-cell class="checkbox-column" *matCellDef="let j">
-      <mat-checkbox class = "checkbox"
-                    (click)="$event.stopPropagation()"
-                    (change)="$event ? selection.toggle(j) : null"
-                    [checked]="selection.isSelected(j)">
-      </mat-checkbox>
-      <a class="job-details-button mat-body-1" [routerLink]="[j.id]" [queryParams]="getQueryParams()">{{ j.name }}</a>
+    <mat-cell *matCellDef="let j">
+        <mat-checkbox class = "checkbox"
+                      (click)="$event.stopPropagation()"
+                      (change)="$event ? selection.toggle(j) : null"
+                      [checked]="selection.isSelected(j)">
+        </mat-checkbox>
     </mat-cell>
   </ng-container>
 
+  <!-- Job name column -->
+  <ng-container matColumnDef="Job">
+    <mat-header-cell *matHeaderCellDef>Job</mat-header-cell>
+    <mat-cell *matCellDef="let j">
+      <a class="job-details-button mat-body-1"
+         [routerLink]="[j.id]"
+         [queryParams]="getQueryParams()">
+         {{ j.name }}
+       </a>
+     </mat-cell>
+   </ng-container>
+
   <!-- Job details dropdown column -->
   <ng-container matColumnDef="Details">
-    <mat-header-cell *matHeaderCellDef></mat-header-cell>
-    <mat-cell *matCellDef="let j">
+    <mat-header-cell class="details-drop-down-cell" *matHeaderCellDef></mat-header-cell>
+    <mat-cell class="details-drop-down-cell" *matCellDef="let j">
       <button mat-icon-button class="jobs-dropdown-arrow"
               [class.visible]="showDropdownArrow(j)"
               [matMenuTriggerFor]="menu">

--- a/ui/src/app/job-list/table/table.component.spec.ts
+++ b/ui/src/app/job-list/table/table.component.spec.ts
@@ -151,7 +151,7 @@ describe('JobsTableComponent', () => {
     testComponent.jobs.next([jobs[0]]);
     fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
-    expect(de.query(By.css('.job-details-button')).nativeElement.textContent)
+    expect(de.query(By.css('.job-details-button')).nativeElement.textContent.trim())
       .toEqual(jobs[0].name);
   }));
 
@@ -161,7 +161,7 @@ describe('JobsTableComponent', () => {
     fixture.detectChanges();
 
     let de: DebugElement = fixture.debugElement;
-    expect(de.query(By.css('.job-details-button')).nativeElement.textContent)
+    expect(de.query(By.css('.job-details-button')).nativeElement.textContent.trim())
       .toEqual(jobs[0].name);
 
 

--- a/ui/src/app/job-list/table/table.component.ts
+++ b/ui/src/app/job-list/table/table.component.ts
@@ -42,8 +42,7 @@ export class JobsTableComponent implements OnInit {
   public selection = new SelectionModel<QueryJobsResult>(/* allowMultiSelect */ true, []);
   public jobs: QueryJobsResult[] = [];
 
-  // TODO(alanhwang): Allow these columns to be configured by the user
-  displayedColumns: string[] = ["Job", "Details"];
+  displayedColumns: string[] = ["Checkbox", "Job", "Details"];
 
   constructor(
     private readonly route: ActivatedRoute,


### PR DESCRIPTION
Fixes the 'stacking' problem of the checkbox and job name for long names:
<img width="980" alt="screen shot 2018-04-16 at 7 39 51 pm" src="https://user-images.githubusercontent.com/1890623/38845830-2f894488-41ae-11e8-83c3-78a76b6eb70c.png">


Accomplished by separating the checkbox and job name columns. Also make the width of the dropdown column much smaller since it was unnecessarily big.