### PR TITLE
[Bug] Fix the issue that filtering on labels doesn't work for Cromwell.

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -256,6 +256,10 @@ def cromwell_query_params(query, page, page_size):
     if query.statuses:
         statuses = [{'status': s} for s in set(query.statuses)]
         query_params.extend(statuses)
+    if query.labels:
+        labels = [{'label': k + ':' + v} for k, v in query.labels.items()]
+        query_params.extend(labels)
+
     query_params.append({'pageSize': str(page_size)})
     query_params.append({'page': str(page)})
     query_params.append({'additionalQueryResultFields': 'parentWorkflowId'})

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -515,6 +515,7 @@ class TestJobsController(BaseTestCase):
                                     datetime_format),
             end=datetime.strptime('2017-10-31T18:04:47.271Z', datetime_format),
             statuses=['Submitted', 'Running', 'Succeeded'],
+            labels={'label-key-1': 'label-val-1', 'label-key-2': 'label-val-2'},
             page_size=100)
         query_params = [{
             'name': query.name
@@ -527,6 +528,10 @@ class TestJobsController(BaseTestCase):
             'pageSize': '100'
         }, {
             'page': '23'
+        }, {
+            'label': 'label-key-1:label-val-1'
+        }, {
+            'label': 'label-key-2:label-val-2'
         }, {
             'additionalQueryResultFields': 'parentWorkflowId'
         }, {

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -515,7 +515,10 @@ class TestJobsController(BaseTestCase):
                                     datetime_format),
             end=datetime.strptime('2017-10-31T18:04:47.271Z', datetime_format),
             statuses=['Submitted', 'Running', 'Succeeded'],
-            labels={'label-key-1': 'label-val-1', 'label-key-2': 'label-val-2'},
+            labels={
+                'label-key-1': 'label-val-1',
+                'label-key-2': 'label-val-2'
+            },
             page_size=100)
         query_params = [{
             'name': query.name


### PR DESCRIPTION
This PR fixes the bug that filtering on labels is not working for Cromwell. 

The reason is that we didn't implement that functionality in Cromwell's controllers before.