### PR TITLE
Job list: drop the "q" param entirely when there are 0 filters

### DIFF
--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -192,10 +192,16 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
       }
     });
     let query: string = URLSearchParamsUtils.encodeURLSearchParamsFromMap(paramMap);
-    this.router.navigate(
-      ['jobs'],
-      {queryParams: { q: query}}
-    );
+    if (query) {
+      this.router.navigate(
+        ['jobs'],
+        {queryParams: { q: query}}
+      );
+    } else if (this.route.snapshot.queryParams['q']) {
+      this.router.navigate(
+        ['jobs']
+      );
+    }
   }
 
   shouldDisplayStatusButtons(): boolean {

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -197,7 +197,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
         ['jobs'],
         {queryParams: { q: query}}
       );
-    } else if (this.route.snapshot.queryParams['q']) {
+    } else {
       this.router.navigate(
         ['jobs']
       );


### PR DESCRIPTION
check for query and query string before searching
see https://elastc.com/c/jPo5zc1X/287-job-list-drop-the-q-param-entirely-when-there-are-0-filters