### PR TITLE
Fix local development for Google workstations

### DIFF
--- a/common-compose.yml
+++ b/common-compose.yml
@@ -1,6 +1,6 @@
 version: '2.1'
 services:
-  ui:
+  jmui:
     build:
       context: ui
       dockerfile: Dockerfile.dev
@@ -42,7 +42,7 @@ services:
     ports:
       - 8190:8190
   jobs-proxy:
-    # Child services must have links named "ui", "api".
+    # Child services must have links named "jmui", "jmapi".
     image: nginx
     volumes:
       - ./nginx.dev.conf:/etc/nginx/nginx.conf

--- a/cromwell-compose-caas.yml
+++ b/cromwell-compose-caas.yml
@@ -1,10 +1,10 @@
 version: '2.1'
 services:
-  ui:
+  jmui:
     extends:
       file: common-compose.yml
-      service: ui
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_caas"]
+      service: jmui
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "jmui", "--env=cromwell_caas"]
   cromwell:
     build:
       context: .
@@ -20,5 +20,5 @@ services:
       file: common-compose.yml
       service: jobs-proxy
     links:
-      - ui
-      - cromwell:api
+      - jmui
+      - cromwell:jmapi

--- a/cromwell-compose-dev.yml
+++ b/cromwell-compose-dev.yml
@@ -1,10 +1,10 @@
 version: '2.1'
 services:
-  ui:
+  jmui:
     extends:
       file: common-compose.yml
-      service: ui
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_dev"]
+      service: jmui
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "jmui", "--env=cromwell_dev"]
   cromwell:
     build:
       context: .
@@ -19,5 +19,5 @@ services:
       file: common-compose.yml
       service: jobs-proxy
     links:
-      - ui
-      - cromwell:api
+      - jmui
+      - cromwell:jmapi

--- a/cromwell-compose-staging.yml
+++ b/cromwell-compose-staging.yml
@@ -1,10 +1,10 @@
 version: '2.1'
 services:
-  ui:
+  jmui:
     extends:
       file: common-compose.yml
-      service: ui
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=cromwell_staging"]
+      service: jmui
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "jmui", "--env=cromwell_staging"]
   cromwell:
     build:
       context: .
@@ -19,5 +19,5 @@ services:
       file: common-compose.yml
       service: jobs-proxy
     links:
-      - ui
-      - cromwell:api
+      - jmui
+      - cromwell:jmapi

--- a/dsub-google-compose.yml
+++ b/dsub-google-compose.yml
@@ -1,13 +1,13 @@
 version: '2.1'
 services:
-  ui:
+  jmui:
     extends:
       file: common-compose.yml
-      service: ui
-    # Use --host "ui" to match the container name, as this is how nginx will
+      service: jmui
+    # Use --host "jmui" to match the container name, as this is how nginx will
     # access the UI on the network. This must match to avoid "Invalid Host"
     # errors. See also https://github.com/angular/angular-cli/issues/6349.
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=dsub_google"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "jmui", "--env=dsub_google"]
   dsub:
     build:
       context: servers
@@ -23,5 +23,5 @@ services:
       file: common-compose.yml
       service: jobs-proxy
     links:
-      - ui
-      - dsub:api
+      - jmui
+      - dsub:jmapi

--- a/dsub-local-compose.yml
+++ b/dsub-local-compose.yml
@@ -1,13 +1,13 @@
 version: '2.1'
 services:
-  ui:
+  jmui:
     extends:
       file: common-compose.yml
-      service: ui
-    # Use --host "ui" to match the container name, as this is how nginx will
+      service: jmui
+    # Use --host "jmui" to match the container name, as this is how nginx will
     # access the UI on the network. This must match to avoid "Invalid Host"
     # errors. See also https://github.com/angular/angular-cli/issues/6349.
-    command: ["npm", "run-script", "ng", "--", "serve", "--host", "ui", "--env=dsub_local"]
+    command: ["npm", "run-script", "ng", "--", "serve", "--host", "jmui", "--env=dsub_local"]
   dsub:
     build:
       context: servers
@@ -31,5 +31,5 @@ services:
       file: common-compose.yml
       service: jobs-proxy
     links:
-      - ui
-      - dsub:api
+      - jmui
+      - dsub:jmapi

--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -20,6 +20,10 @@ http {
               }
               location / {
                 proxy_pass http://jmui;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header Host $host;
               }
         }
 }

--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -5,21 +5,21 @@ events {}
 http {
         # These host names are available in a docker-compose environment via
         # docker linking.
-        upstream ui {
-                server ui:4200;
+        upstream jmui {
+                server jmui:4200;
         }
-        upstream api {
-                server api:8190;
+        upstream jmapi {
+                server jmapi:8190;
         }
         server {
               listen 4200;
               # All API requests have a version prefix. Route everything else to
               # the UI server.
               location /api {
-                proxy_pass http://api;
+                proxy_pass http://jmapi;
               }
               location / {
-                proxy_pass http://ui;
+                proxy_pass http://jmui;
               }
         }
 }


### PR DESCRIPTION
"api" has a DNS mapping now internally for us. Apparently our workstation DNS mapping supersedes the internal docker network.

I couldn't figure out how to reconfigure that - switching to an internal only docker network makes the proxy inaccessible locally. So I took the easy way out and just used a different service name.