### PR TITLE
fix Cromwell bug where "of many" shows up when there's only one page

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -206,7 +206,7 @@ def query_jobs(body, **kwargs):
         offset = offset + page_size
         page = page_from_offset(offset, page_size)
 
-    if query_page_size > len(results):
+    if query_page_size >= len(results):
         return QueryJobsResponse(results=results)
 
     next_page_token = page_tokens.encode_offset(offset)

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -206,6 +206,9 @@ def query_jobs(body, **kwargs):
         offset = offset + page_size
         page = page_from_offset(offset, page_size)
 
+    if query_page_size > len(results):
+        return QueryJobsResponse(results=results)
+
     next_page_token = page_tokens.encode_offset(offset)
     return QueryJobsResponse(results=results, next_page_token=next_page_token)
 

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -206,7 +206,7 @@ def query_jobs(body, **kwargs):
         offset = offset + page_size
         page = page_from_offset(offset, page_size)
 
-    if query_page_size >= len(results):
+    if query_page_size >= total_results:
         return QueryJobsResponse(results=results)
 
     next_page_token = page_tokens.encode_offset(offset)


### PR DESCRIPTION
 - aligned return from query_jobs in cromwell to query_jobs in dsub when it comes to page_token

see: https://elastc.com/c/C46fjeNX/320-bug-when-there-s-only-one-page-it-still-says-of-many