### PR TITLE
[dsub] Correctly check if _SCRIPT exists in envs

### DIFF
--- a/servers/dsub/jobs/controllers/utils/extensions.py
+++ b/servers/dsub/jobs/controllers/utils/extensions.py
@@ -13,7 +13,7 @@ def get_extensions(job):
     """
     envs = job['envs']
     script = None
-    if envs and envs['_SCRIPT']:
+    if envs and '_SCRIPT' in envs:
         script = envs['_SCRIPT']
         del envs['_SCRIPT']
 


### PR DESCRIPTION
This is needed for the local provider where '_SCRIPT' is not set.