### PR TITLE
Preset --sourcemaps=false to improve test failures

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -19,12 +19,12 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 ## Running Tests
 Unit tests are run via [Karma](https://karma-runner.github.io).
 ```
-ng test
+npm test
 ```
 
 By default, this opens a browser. Alternatively run headless:
 ```
-ng test --browsers=ChromeHeadless
+npm test -- --browsers=ChromeHeadless
 ```
 
 ## Further help

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "ng test",
+    "test": "ng test --sourcemaps=false",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
This only works if you run `npm test` directly (not if you run `ng test`), but at least it also serves as documentation of the flag.