### PR TITLE
Cromwell shim: don't write python pyc files

### DIFF
--- a/common-compose.yml
+++ b/common-compose.yml
@@ -38,6 +38,7 @@ services:
       - CAPABILITIES_CONFIG=/app/jobs/capabilities_config.json
       - CROMWELL_URL=${CROMWELL_URL}
       - GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-"--workers=5"}
+      - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ./servers/cromwell/jobs:/app/jobs
     ports:


### PR DESCRIPTION
This causes problems with our docker compose setup. If we leave this setting on, then the Python server will generate .pyc files within docker. This causes problems because it writes files to our source directory (via mounted volume) and we run docker as "root" (the files are owned by that user).

The end result is write-protected .pyc files in the source directory, which means you'll need to manually remove them or use sudo if you want to rebuild the local docker images.

Furthermore, I don't like the potential issues you hit if you remove a py source file, but forget to move the pyc file.