### PR TITLE
Automate 'Updating the API using swagger-codegen'

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,21 +130,25 @@ https://github.com/angular/angular-cli/issues/6349).
 ### Updating the API using swagger-codegen
 
 We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to automatically implement the API, as defined in `api/jobs.yaml`, for all
-servers and the UI. Whenever the API is updated, follow these steps to update the server implementations:
+servers and the UI. 
 
-#### Scripted
+Whenever the API is updated, follow these steps to update the server implementations. **Note:** after updating the API you 
+will need to test and update the server implementations to resolve any broken dependencies on old API definitions or 
+implement additional functionality to match the new specs. 
 
 From the base of the checked-out job-manager repository, run:
 ```sh
 scripts/rebuild_swagger.sh
 ```
 
-This will find and download `swagger-codegen-cli.jar`, remove the necessary build artifacts and use `swagger-codegen-cli.jar` to
-regenerate them. 
+This will:
+ - Find and download `swagger-codegen-cli.jar`
+ - Remove the necessary build artifacts 
+ - Use `swagger-codegen-cli.jar` to regenerate them. 
 
 If you prefer to do this manually you can fallow the instructions below.
 
-#### Manually
+#### Manual Process
 
 If you prefer to perform the steps manually, you can:
 
@@ -181,7 +185,6 @@ If you prefer to perform the steps manually, you can:
       -o servers/cromwell \
       -DsupportPython2=true,packageName=jobs
       ```
-4. Update the server implementations to resolve any broken dependencies on old API definitions or implement additional functionality to match the new specs.
 
 ## Job Manager UI Server
 For UI server documentation, see [ui](ui/).

--- a/README.md
+++ b/README.md
@@ -144,12 +144,15 @@ scripts/rebuild_swagger.sh
 If you prefer to perform the steps manually, you can:
 
 1. If you do not already have the jar, you can download it here:
+ 
     ```
-    # Linux
-    wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
-    # macOS
-    brew install swagger-codegen
+      # Using wget:
+      wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
+      
+      # Or, using curl:
+      curl http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar > swagger-codegen-cli.jar
     ```
+    
 2. Clear out existing generated models:
     ```
     rm ui/src/app/shared/model/*

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ From the base of the checked-out job-manager repository, run:
 scripts/rebuild_swagger.sh
 ```
 
+This will find and download `swagger-codegen-cli.jar`, remove the necessary build artifacts and use `swagger-codegen-cli.jar` to
+regenerate them. 
+
+If you prefer to do this manually you can fallow the instructions below.
+
 #### Manually
 
 If you prefer to perform the steps manually, you can:

--- a/README.md
+++ b/README.md
@@ -130,11 +130,10 @@ https://github.com/angular/angular-cli/issues/6349).
 ### Updating the API using swagger-codegen
 
 We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to automatically implement the API, as defined in `api/jobs.yaml`, for all
-servers and the UI. 
+servers and the UI. Whenever the API is updated, follow these steps to update the server implementations. 
 
-Whenever the API is updated, follow these steps to update the server implementations. **Note:** after updating the API you 
-will need to test and update the server implementations to resolve any broken dependencies on old API definitions or 
-implement additional functionality to match the new specs. 
+**Note:** after updating the API files you will need to test and update the server implementations to resolve any broken dependencies on old 
+API definitions or implement additional functionality to match the new specs. 
 
 From the base of the checked-out job-manager repository, run:
 ```sh

--- a/README.md
+++ b/README.md
@@ -128,9 +128,20 @@ https://github.com/angular/angular-cli/issues/6349).
   ```
 
 ### Updating the API using swagger-codegen
+
 We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to automatically implement the API, as defined in `api/jobs.yaml`, for all
-servers and the UI. Whenever the API is updated, follow these steps to
-update the server implementations:
+servers and the UI. Whenever the API is updated, follow these steps to update the server implementations:
+
+#### Scripted
+
+From the base of the checked-out job-manager repository, run:
+```sh
+scripts/rebuild_swagger.sh
+```
+
+#### Manually
+
+If you prefer to perform the steps manually, you can:
 
 1. If you do not already have the jar, you can download it here:
     ```

--- a/scripts/rebuild_swagger.sh
+++ b/scripts/rebuild_swagger.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+if [[ ! -d "ui" ]] 
+then
+  echo "Cannot find expected directory 'ui'. Did you run the rebuild script from somewhere unexpected?" >&2 
+  echo "You must run this script from the base of the job-manager directory like '. scripts/rebuild_swagger.sh'" >&2 
+  exit 1 
+fi
+
+if [[ ! -e "swagger-codegen-cli.jar" ]]
+then
+  if [[ -e "$(command -v wget)" ]]; then
+    wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
+  elif [[ -e "$(command -v curl)" ]]; then
+    curl http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar > swagger-codegen-cli.jar
+  else
+    "Cannot download 'http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar' automatically (no curl or wget found on PATH)"
+    "You can download it manually into this directory to continue"
+  fi
+fi
+
+[[ -d "ui/src/app/shared/model" ]] || rm ui/src/app/shared/model/*
+[[ -d "servers/dsub/jobs/models" ]] || rm servers/dsub/jobs/models/*
+[[ -d "servers/cromwell/jobs/models" ]] || rm servers/cromwell/jobs/models/*
+
+java -jar swagger-codegen-cli.jar generate \
+  -i api/jobs.yaml \
+  -l typescript-angular2 \
+  -o ui/src/app/shared
+
+java -jar swagger-codegen-cli.jar generate \
+  -i api/jobs.yaml \
+  -l python-flask \
+  -o servers/dsub \
+  -DsupportPython2=true,packageName=jobs
+
+java -jar swagger-codegen-cli.jar generate \
+  -i api/jobs.yaml \
+  -l python-flask \
+  -o servers/cromwell \
+  -DsupportPython2=true,packageName=jobs
+
+echo "Done!"


### PR DESCRIPTION
One day it might be nice to coordinate the entire rebuild process using a make script, but until then this script automates the steps in the [Updating the API using Swagger Codegen](https://github.com/DataBiosphere/job-manager/tree/cjl_rebuild_swagger_script#updating-the-api-using-swagger-codegen) section of the docs (link goes to my updated version of the docs).

EDIT: I've also removed the suggestion to `brew install swagger-codegen` since when I did that it was missing a key `typescript-angular2` generator class.