### PR TITLE
pass parameters to nosetest to reduce log spam on backend test logs

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -131,7 +131,7 @@ def format_task(task_name, task_metadata):
     return TaskMetadata(
         name=remove_workflow_name(task_name),
         execution_id=task_metadata.get('jobId'),
-        execution_status=task_statuses.cromwell_workflow_status_to_api(
+        execution_status=task_statuses.cromwell_execution_to_api(
             task_metadata.get('executionStatus')),
         start=_parse_datetime(task_metadata.get('start')),
         end=_parse_datetime(task_metadata.get('end')),

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -131,7 +131,7 @@ def format_task(task_name, task_metadata):
     return TaskMetadata(
         name=remove_workflow_name(task_name),
         execution_id=task_metadata.get('jobId'),
-        execution_status=task_statuses.cromwell_execution_to_api(
+        execution_status=task_statuses.cromwell_workflow_status_to_api(
             task_metadata.get('executionStatus')),
         start=_parse_datetime(task_metadata.get('start')),
         end=_parse_datetime(task_metadata.get('end')),

--- a/servers/cromwell/tox.ini
+++ b/servers/cromwell/tox.ini
@@ -6,5 +6,5 @@ deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
        
 commands=
-   nosetests \
-      [--logging-level=WARN]
+   nosetests --logging-level=WARN \
+      []

--- a/servers/cromwell/tox.ini
+++ b/servers/cromwell/tox.ini
@@ -7,4 +7,4 @@ deps=-r{toxinidir}/requirements.txt
        
 commands=
    nosetests \
-      []
+      [--logging-level=WARN]

--- a/servers/dsub/tox.ini
+++ b/servers/dsub/tox.ini
@@ -8,4 +8,4 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 
-commands= nosetests []
+commands= nosetests --logging-level=WARN []


### PR DESCRIPTION
passing `--logging-level=WARN` to calls to `nosetests` for back-end testing