### PR TITLE
Usage documentation for the rebuild-swagger service

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,20 @@ https://github.com/angular/angular-cli/issues/6349).
 
 ### Updating the API using swagger-codegen
 
-We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to automatically generate the API classes
-defined in `api/jobs.yaml` for the servers and for the UI. 
-Whenever the API is updated, re-run `docker-compose up rebuild-swagger` to trigger a rebuild.
+* We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to transform the API 
+defined in `api/jobs.yaml` into appropriate classes for the servers and the UI to use.
+* Whenever the API is updated, run this to trigger a rebuild: 
+```sh
+docker-compose up rebuild-swagger
+```
  
-**Note:** the `rebuild-swagger` job does nothing if the file `api/jobs.yaml` has not changed since the
+**Notes** 
+
+* The `rebuild-swagger` job does nothing if the file `api/jobs.yaml` has not changed since the
 last time it was run.
-
-**Note:** the `rebuild-swagger` job will run by default during `docker-compose up` to generate the swagger for the other 
+* The `rebuild-swagger` job will run by default during `docker-compose up` to generate the swagger for the other 
 services if necessary. The other services will not start until their swagger classes exist.
-
-**Note:** after regenerating the model files, you'll need to test and update the server implementations to 
+* After regenerating the model files, you'll need to test and update the server implementations to 
 resolve any broken dependencies on old API definitions or implement additional functionality to match the new specs. 
 
 ## Job Manager UI Server

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ defined in `api/jobs.yaml` into appropriate classes for the servers and the UI t
 docker-compose up rebuild-swagger
 ```
  
-**Notes** 
+#### Swagger codegen notes
 
 * The `rebuild-swagger` job does nothing if the file `api/jobs.yaml` has not changed since the
 last time it was run.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to auto
 defined in `api/jobs.yaml` for the servers and for the UI. 
 Whenever the API is updated, re-run `docker-compose up rebuild-swagger` to trigger a rebuild.
  
-**Note:** the `swagger-rebuild` job does nothing if the file `api/jobs.yaml` has not changed since the
+**Note:** the `rebuild-swagger` job does nothing if the file `api/jobs.yaml` has not changed since the
 last time it was run.
 
 **Note:** the `rebuild-swagger` job will run by default during `docker-compose up` to generate the swagger for the other 

--- a/README.md
+++ b/README.md
@@ -147,61 +147,18 @@ https://github.com/angular/angular-cli/issues/6349).
 
 ### Updating the API using swagger-codegen
 
-We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to automatically implement the API, as defined in `api/jobs.yaml`, for all
-servers and the UI. Whenever the API is updated, follow these steps to update the server implementations. 
-
-**Note:** after updating the API files you will need to test and update the server implementations to resolve any broken dependencies on old 
-API definitions or implement additional functionality to match the new specs. 
-
-From the base of the checked-out job-manager repository, run:
-```sh
-scripts/rebuild_swagger.sh
-```
-
-This will:
- - Find and download `swagger-codegen-cli.jar`
- - Remove the necessary build artifacts 
- - Use `swagger-codegen-cli.jar` to regenerate them. 
-
-If you prefer to do this manually you can fallow the instructions below.
-
-#### Manual Process
-
-If you prefer to perform the steps manually, you can:
-
-1. If you do not already have the jar, you can download it here:
+We use [swagger-codegen](https://github.com/swagger-api/swagger-codegen) to automatically generate the API classes
+defined in `api/jobs.yaml` for the servers and for the UI. 
+Whenever the API is updated, re-run `docker-compose up rebuild-swagger` to trigger a rebuild.
  
-    ```
-      # Using wget:
-      wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
-      
-      # Or, using curl:
-      curl http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar > swagger-codegen-cli.jar
-    ```
-    
-2. Clear out existing generated models:
-    ```
-    rm ui/src/app/shared/model/*
-    rm servers/dsub/jobs/models/*
-    rm servers/cromwell/jobs/models/*
-    ```
-3. Regenerate both the python and angular definitions.
-    ```
-    java -jar swagger-codegen-cli.jar generate \
-      -i api/jobs.yaml \
-      -l typescript-angular2 \
-      -o ui/src/app/shared
-      java -jar swagger-codegen-cli.jar generate \
-      -i api/jobs.yaml \
-      -l python-flask \
-      -o servers/dsub \
-      -DsupportPython2=true,packageName=jobs
-      java -jar swagger-codegen-cli.jar generate \
-      -i api/jobs.yaml \
-      -l python-flask \
-      -o servers/cromwell \
-      -DsupportPython2=true,packageName=jobs
-      ```
+**Note:** the `swagger-rebuild` job does nothing if the file `api/jobs.yaml` has not changed since the
+last time it was run.
+
+**Note:** the `rebuild-swagger` job will run by default during `docker-compose up` to generate the swagger for the other 
+services if necessary. The other services will not start until their swagger classes exist.
+
+**Note:** after regenerating the model files, you'll need to test and update the server implementations to 
+resolve any broken dependencies on old API definitions or implement additional functionality to match the new specs. 
 
 ## Job Manager UI Server
 For UI server documentation, see [ui](ui/).


### PR DESCRIPTION
I've removed the "manual process" section since that wouldn't generate the `.md5` files which the services are keying off for "should I start yet".