### PR TITLE
Re-add link to timing diagram

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -85,6 +85,8 @@ def get_job(id, **kwargs):
     """
     url = '{cromwell_url}/{id}/metadata'.format(
         cromwell_url=_get_base_url(), id=id)
+    timing_url = '{cromwell_url}/{id}/timing'.format(
+        cromwell_url=_get_base_url(), id=id)
     response = requests.get(
         url, auth=kwargs.get('auth'), headers=kwargs.get('auth_headers'))
     job = response.json()
@@ -125,7 +127,7 @@ def get_job(id, **kwargs):
         outputs=update_key_names(job.get('outputs', {})),
         labels=job.get('labels'),
         failures=failures,
-        extensions=ExtendedFields(tasks=sorted_tasks))
+        extensions=ExtendedFields(tasks=sorted_tasks, timing_url=timing_url))
 
 
 def format_task(task_name, task_metadata):

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -422,7 +422,8 @@ class TestJobsController(BaseTestCase):
                     'returnCode': return_code,
                     'attempts': attempts,
                     'jobId': subworkflow_id
-                }]
+                }],
+                'timingUrl': "https://test-cromwell.org/id/timing"
             }
         }  # yapf: disable
         self.assertDictEqual(response_data, expected_data)
@@ -525,7 +526,8 @@ class TestJobsController(BaseTestCase):
                         'count': 2,
                         'status': 'Failed'
                     }]
-                }]
+                }],
+                'timingUrl': "https://test-cromwell.org/id/timing"
             }
         }  # yapf: disable
         self.assertDictEqual(response_data, expected_data)


### PR DESCRIPTION
~~Shows up in the status pane. Closes #318~~ 

<img width="434" alt="screen shot 2018-08-01 at 5 03 08 pm" src="https://user-images.githubusercontent.com/13006282/43548837-f58ead74-95ac-11e8-9872-8b057d045741.png">

---

EDIT: Ignore that picture! I moved this back to the "Tasks" section where it was before. That doesn't feel like a great final location for it because ultimately we should be able to draw a timing diagram for `dsub` jobs too, and they don't use the tasks panel, but for now it's good enough