### PR TITLE
Fix prod docker files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,17 @@ From v0.2.0, Job Manager starts to release stock docker images on [DockerHub](ht
 
 - To build the `job-manager-ui` image with `$TAG` from the root of this Github repository:
     ```
-    cd ui && docker build -t job-manager-ui:$TAG . -f Dockerfile
+    docker build -t job-manager-ui:$TAG . -f ui/Dockerfile
     ```
     
 - **Cromwell:** To build the `job-manager-api-cromwell` image with `$TAG` from the root of this Github repository:
     ```
-    docker build -t job-manager-api-cromwell:v0.2.0 . -f servers/cromwell/Dockerfile
+    docker build -t job-manager-api-cromwell:$TAG . -f servers/cromwell/Dockerfile
     ```
     
 - **dsub:** To build the `job-manager-api-dsub` image with `$TAG` from the root of this Github repository:
     ```
-    cd servers && docker build -t job-manager-api-dsub:v0.2.0 . -f dsub/Dockerfile
+    docker build -t job-manager-api-dsub:$TAG . -f servers/dsub/Dockerfile
     ```
 
 ### Add a github release pointing to the dockerhub images

--- a/servers/cromwell/Dockerfile
+++ b/servers/cromwell/Dockerfile
@@ -1,14 +1,24 @@
+FROM openjdk
+
+WORKDIR /job-manager
+
+ADD ./ /job-manager
+
+RUN /bin/bash -c scripts/rebuild_swagger.sh
+RUN scripts/await_md5_match.sh /job-manager/ui/src/app/shared/model/.jobs.yaml.md5
+
 FROM gcr.io/google-appengine/python
 
 WORKDIR /app
 
-ADD servers/jm_utils /app/jm_utils
-ADD servers/cromwell/jobs /app/jobs
-COPY servers/cromwell/requirements.txt /app/jobs
+COPY --from=0 /job-manager/servers/jm_utils /app/jm_utils
+COPY --from=0 /job-manager/servers/cromwell/jobs /app/jobs
+COPY ./servers/cromwell/requirements.txt /app/jobs
+
 RUN cd jobs && pip install -r requirements.txt
 # We installed jm_utils so don't need local copy anymore, which breaks imports
 RUN rm -rf jm_utils
 
 # Missing required arguments -b PORT, -e ... which must be provided by the
 # docker image user.
-ENTRYPOINT ["/bin/bash", "/scripts/await_md5_match.sh", "/app/jobs/models/.jobs.yaml.md5", "--", "gunicorn", "jobs:run()"]
+ENTRYPOINT ["gunicorn", "jobs:run()"]

--- a/servers/dsub/Dockerfile
+++ b/servers/dsub/Dockerfile
@@ -1,3 +1,12 @@
+FROM openjdk
+
+WORKDIR /job-manager
+
+ADD ./ /job-manager
+
+RUN /bin/bash -c scripts/rebuild_swagger.sh
+RUN scripts/await_md5_match.sh /job-manager/ui/src/app/shared/model/.jobs.yaml.md5
+
 FROM gcr.io/google-appengine/python
 RUN virtualenv --no-download /env -p python
 
@@ -7,13 +16,13 @@ ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 
 WORKDIR /app
-ADD jm_utils /app/jm_utils
-ADD dsub/jobs /app/jobs
-ADD dsub/requirements.txt /app/jobs
+COPY --from=0 /job-manager/servers/jm_utils /app/jm_utils
+COPY --from=0 /job-manager/servers/dsub/jobs /app/jobs
+COPY ./servers/dsub/requirements.txt /app/jobs
 RUN cd jobs && pip install -r requirements.txt
 # We installed jm_utils so don't need local copy anymore, which breaks imports
 RUN rm -rf jm_utils
 
 # Missing required arguments -b PORT, -e ... which must be provided by the
 # docker image user.
-ENTRYPOINT ["/bin/bash", "/scripts/await_md5_match.sh", "/app/jobs/models/.jobs.yaml.md5", "--", "/env/bin/gunicorn", "jobs.__main__:app"]
+ENTRYPOINT ["/env/bin/gunicorn", "jobs.__main__:app"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,14 +1,28 @@
+FROM openjdk
+
+WORKDIR /job-manager
+
+ADD ./ /job-manager
+
+RUN /bin/bash -c scripts/rebuild_swagger.sh
+RUN scripts/await_md5_match.sh /job-manager/ui/src/app/shared/model/.jobs.yaml.md5
+
 FROM node
 
 WORKDIR /ui
-ADD package-lock.json package.json tsconfig.json .angular-cli.json /ui/
+
+COPY --from=0 /job-manager/ui/src /ui/src
+
+ADD ./ui/package-lock.json /ui/
+ADD ./ui/package.json /ui/
+ADD ./ui/tsconfig.json /ui/
+ADD ./ui/.angular-cli.json /ui/
+
 RUN npm install
 
-ADD src /ui/src
-RUN node_modules/.bin/ng build --prod
+RUN /ui/node_modules/.bin/ng build --prod
 
 FROM nginx
 
-COPY --from=0 /ui/dist /ui/dist
-ADD nginx.prod.conf /etc/nginx/nginx.conf
-ENTRYPOINT [ "/scripts/await_md5_match.sh", "/ui/src/app/shared/model/.jobs.yaml.md5", "--" ]
+COPY --from=1 /ui/dist /ui/dist
+ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf

--- a/ui/nginx.prod.conf
+++ b/ui/nginx.prod.conf
@@ -13,8 +13,8 @@ http {
 
     # If we're running on App Engine, logs will appear on the Google Developer's
     # Console when logged to this directory.
-    access_log /var/log/app_engine/app.log;
-    error_log /var/log/app_engine/app.log;
+    # access_log /var/log/app_engine/app.log;
+    # error_log /var/log/app_engine/app.log;
 
     gzip on;
     gzip_disable "msie6";


### PR DESCRIPTION
I noticed that the docker files for prod are broken, for they are missing the generated models, which are required by `ng build --prod`. 

I think the reason why it was not identified for a while is that we used `ng build --target=production --env=dev` in the UI test, which doesn't have the exact same build mechanism with `ng build --prod`.

