### PR TITLE
Support retryable dsub jobs

### DIFF
--- a/servers/dsub/jobs/controllers/aggregation_controller.py
+++ b/servers/dsub/jobs/controllers/aggregation_controller.py
@@ -117,7 +117,7 @@ def _to_top_labels_aggregations(label_summaries):
     label_freq = {}
     for label, item in label_summaries.items():
         # job-id and task-id are assigned by dsub and are not meaningful for aggregation
-        if label == 'job-id' or label == 'task-id' or labe == 'task-attempt':
+        if label == 'job-id' or label == 'task-id' or label == 'task-attempt':
             continue
         total_count = 0
         for _, counts in item.items():

--- a/servers/dsub/jobs/controllers/aggregation_controller.py
+++ b/servers/dsub/jobs/controllers/aggregation_controller.py
@@ -117,7 +117,7 @@ def _to_top_labels_aggregations(label_summaries):
     label_freq = {}
     for label, item in label_summaries.items():
         # job-id and task-id are assigned by dsub and are not meaningful for aggregation
-        if label == 'job-id' or label == 'task-id':
+        if label == 'job-id' or label == 'task-id' or labe == 'task-attempt':
             continue
         total_count = 0
         for _, counts in item.items():

--- a/servers/dsub/jobs/controllers/capabilities_controller.py
+++ b/servers/dsub/jobs/controllers/capabilities_controller.py
@@ -19,11 +19,12 @@ def get_capabilities():
             DisplayField(field='submission', display='Submitted'),
             DisplayField(field='labels.job-id', display='Job ID'),
             DisplayField(field='labels.task-id', display='Task ID'),
+            DisplayField(field='labels.attempt', display='Attempt'),
             DisplayField(field='extensions.userId', display='User ID'),
             DisplayField(
                 field='extensions.statusDetail', display='Status Detail'),
         ],
-        common_labels=['job-id', 'task-id'],
+        common_labels=['job-id', 'task-id', 'attempt'],
         query_extensions=['userId'])
 
     if _provider_type() in [ProviderType.GOOGLE, ProviderType.GOOGLE_V2]:

--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -28,8 +28,8 @@ def abort_job(id):
     """
     # Attempt is unused in aborting because only one attempt can be running at
     # a time.
-    project, job, task, _ = job_ids.api_to_dsub(id, _provider_type())
-    provider = providers.get_provider(_provider_type(), project, _auth_token())
+    proj_id, job_id, task_id, _ = job_ids.api_to_dsub(id, _provider_type())
+    provider = providers.get_provider(_provider_type(), proj_id, _auth_token())
 
     # TODO(bryancrampton): Add flag to ddel to support deleting only
     # 'singleton' tasks.
@@ -49,8 +49,8 @@ def abort_job(id):
     deleted = execute_redirect_stdout(lambda:
         ddel.ddel_tasks(
             provider=provider,
-            job_ids={job},
-            task_ids={task} if task else None))
+            job_ids={job_id},
+            task_ids={task_id} if task_id else None))
     if len(deleted) != 1:
         raise InternalServerError('Failed to abort dsub job')
 
@@ -85,7 +85,7 @@ def get_job(id):
             provider=provider,
             statuses={'*'},
             job_ids={job_id},
-            task_ids={task_id} if task else None,
+            task_ids={task_id} if task_id else None,
             task_attempts={attempt} if attempt else None,
             full_output=True).next())
     except apiclient.errors.HttpError as error:

--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -29,7 +29,7 @@ def abort_job(id):
     # Attempt is unused in aborting because only one attempt can be running at
     # a time.
     project, job, task, _ = job_ids.api_to_dsub(id, _provider_type())
-    provider = providers.get_provider(_provider_type(), proj_id, _auth_token())
+    provider = providers.get_provider(_provider_type(), project, _auth_token())
 
     # TODO(bryancrampton): Add flag to ddel to support deleting only
     # 'singleton' tasks.
@@ -49,7 +49,7 @@ def abort_job(id):
     deleted = execute_redirect_stdout(lambda:
         ddel.ddel_tasks(
             provider=provider,
-            job_ids={job_id},
+            job_ids={job},
             task_ids= {task} if task else None))
     if len(deleted) != 1:
         raise InternalServerError('Failed to abort dsub job')
@@ -92,12 +92,9 @@ def get_job(id):
 
     # A job_id and task_id define a unique job (should only be one)
     if len(jobs) > 1:
-        raise BadRequest('Found more than one job with ID {}+{}'.format(
-            job_id, task_id))
+        raise BadRequest('Found more than one job with ID {}'.format(id))
     elif len(jobs) == 0:
-        raise NotFound('Could not find any jobs with ID {}+{}'.format(
-            job_id, task_id))
-
+        raise NotFound('Could not find any jobs with ID {}'.format(id))
     return _metadata_response(id, jobs[0])
 
 

--- a/servers/dsub/jobs/controllers/jobs_controller.py
+++ b/servers/dsub/jobs/controllers/jobs_controller.py
@@ -50,7 +50,7 @@ def abort_job(id):
         ddel.ddel_tasks(
             provider=provider,
             job_ids={job},
-            task_ids= {task} if task else None))
+            task_ids={task} if task else None))
     if len(deleted) != 1:
         raise InternalServerError('Failed to abort dsub job')
 
@@ -75,20 +75,21 @@ def get_job(id):
     Returns:
         JobMetadataResponse: Response containing relevant metadata
     """
-    project, job, task, attempt = job_ids.api_to_dsub(id, _provider_type())
-    provider = providers.get_provider(_provider_type(), project, _auth_token())
+    proj_id, job_id, task_id, attempt = job_ids.api_to_dsub(
+        id, _provider_type())
+    provider = providers.get_provider(_provider_type(), proj_id, _auth_token())
 
     jobs = []
     try:
         jobs = execute_redirect_stdout(lambda: dstat.dstat_job_producer(
             provider=provider,
             statuses={'*'},
-            job_ids={job},
-            task_ids={task} if task else None,
+            job_ids={job_id},
+            task_ids={task_id} if task else None,
             task_attempts={attempt} if attempt else None,
             full_output=True).next())
     except apiclient.errors.HttpError as error:
-        _handle_http_error(error, project)
+        _handle_http_error(error, proj_id)
 
     # A job_id and task_id define a unique job (should only be one)
     if len(jobs) > 1:

--- a/servers/dsub/jobs/controllers/utils/job_ids.py
+++ b/servers/dsub/jobs/controllers/utils/job_ids.py
@@ -24,9 +24,8 @@ def api_to_dsub(api_id, provider_type):
     if len(id_split) != 4:
         raise BadRequest(
             'Job ID format is: <project-id>+<job-id>+<task-id>+<attempt>')
-    project, job, task, attempt = id_split
     google_providers = [ProviderType.GOOGLE, ProviderType.GOOGLE_V2]
-    if not project and provider_type in google_providers:
+    if not id_split[0] and provider_type in google_providers:
         raise BadRequest(
             'Job ID is missing project ID component with google provider')
     return id_split

--- a/servers/dsub/jobs/controllers/utils/job_ids.py
+++ b/servers/dsub/jobs/controllers/utils/job_ids.py
@@ -13,41 +13,26 @@ def api_to_dsub(api_id, provider_type):
                 used. Currently the options are google, local, or stub.
 
         Returns:
-            (str, str, str): dsub project, job, task IDs respectively. The job
-                ID will never be None, but both project ID and task ID can be.
+            (str, str, str, str): dsub project ID, job ID, task ID, and attempt
+                number, respectively. The job ID will never be empty, but
+                project ID, task ID, and attempt number may be.
 
         Raises:
             BadRequest if the api_id format is invalid for the given provider
     """
-    project, job, task = None, None, None
     id_split = api_id.split('+')
-
-    if provider_type in [ProviderType.GOOGLE, ProviderType.GOOGLE_V2]:
-        # If we are running on Google cloud the id format should be:
-        # <project-id>+<job-id>+<task-id> or <project-id>+<job-id> if there is
-        # no task ID
-        if len(id_split) == 2:
-            project, job = id_split
-        elif len(id_split) == 3:
-            project, job, task = id_split
-        else:
-            raise BadRequest('Job ID format for google provider is: ' +
-                             '<project-id>+<job-id>[+<task-id>]?')
-    else:
-        # Otherwise, the id format should be: <job-id>+<task-id> or <job-id> if
-        # there is no task ID
-        if len(id_split) == 1:
-            job = id_split[0]
-        elif len(id_split) == 2:
-            job, task = id_split
-        else:
-            raise BadRequest('Job ID format for non-google provider is: ' +
-                             '<job-id>[+<task-id>]?')
-
-    return project, job, task
+    if len(id_split) != 4:
+        raise BadRequest(
+            'Job ID format is: <project-id>+<job-id>+<task-id>+<attempt>')
+    project, job, task, attempt = id_split
+    google_providers = [ProviderType.GOOGLE, ProviderType.GOOGLE_V2]
+    if not project and provider_type in google_providers:
+        raise BadRequest(
+            'Job ID is missing project ID component with google provider')
+    return id_split
 
 
-def dsub_to_api(proj_id, job_id, task_id):
+def dsub_to_api(proj_id, job_id, task_id, attempt):
     """Convert a dsub project, job, and task IDs to an API ID
 
         Args:
@@ -61,13 +46,6 @@ def dsub_to_api(proj_id, job_id, task_id):
         Raises:
             BadRequest if no job_id is provided
     """
-    if proj_id and job_id and task_id:
-        return '{}+{}+{}'.format(proj_id, job_id, task_id)
-    elif proj_id and job_id:
-        return '{}+{}'.format(proj_id, job_id)
-    elif job_id and task_id:
-        return '{}+{}'.format(job_id, task_id)
-    elif job_id:
-        return job_id
-    else:
+    if not job_id:
         raise BadRequest('Invalid dsub ID format, no job_id was provided')
+    return '{}+{}+{}+{}'.format(proj_id, job_id, task_id, attempt)

--- a/servers/dsub/jobs/controllers/utils/job_ids.py
+++ b/servers/dsub/jobs/controllers/utils/job_ids.py
@@ -48,4 +48,5 @@ def dsub_to_api(proj_id, job_id, task_id, attempt):
     """
     if not job_id:
         raise BadRequest('Invalid dsub ID format, no job_id was provided')
-    return '{}+{}+{}+{}'.format(proj_id, job_id, task_id, attempt)
+    return '{}+{}+{}+{}'.format(proj_id or '', job_id or '', task_id or '',
+                                attempt or '')

--- a/servers/dsub/jobs/controllers/utils/jobs_generator.py
+++ b/servers/dsub/jobs/controllers/utils/jobs_generator.py
@@ -1,7 +1,6 @@
 import datetime
 
 from dsub.commands import ddel, dstat
-from flask import current_app
 
 from jobs.common import execute_redirect_stdout
 from jobs.controllers.utils import extensions, failures, job_ids, job_statuses, labels, providers, query_parameters
@@ -38,7 +37,6 @@ def generate_jobs(provider, query, create_time_max=None, offset_id=None):
         create_time_min = query.start - datetime.timedelta(
             days=_MAX_RUNTIME_DAYS)
 
-    current_app.logger.info('DSTAT_PARAMS "%s"', dstat_params)
     jobs = execute_redirect_stdout(lambda: dstat.lookup_job_tasks(
         provider=provider,
         statuses=dstat_params['statuses'],
@@ -125,10 +123,10 @@ def generate_jobs_by_window(provider, project_id, window_min, window_max=None):
         yield job
 
 
-def _query_jobs_result(job, project_id=''):
+def _query_jobs_result(job, project_id=None):
     return QueryJobsResult(
-        id=job_ids.dsub_to_api(project_id, job['job-id'], job.get(
-            'task-id', ''), job.get('task-attempt', '')),
+        id=job_ids.dsub_to_api(project_id, job['job-id'], job.get('task-id'),
+                               job.get('task-attempt')),
         name=job['job-name'],
         status=job_statuses.dsub_to_api(job),
         # The LocalJobProvider returns create-time with millisecond granularity.

--- a/servers/dsub/jobs/controllers/utils/jobs_generator.py
+++ b/servers/dsub/jobs/controllers/utils/jobs_generator.py
@@ -1,6 +1,7 @@
 import datetime
 
 from dsub.commands import ddel, dstat
+from flask import current_app
 
 from jobs.common import execute_redirect_stdout
 from jobs.controllers.utils import extensions, failures, job_ids, job_statuses, labels, providers, query_parameters
@@ -37,12 +38,14 @@ def generate_jobs(provider, query, create_time_max=None, offset_id=None):
         create_time_min = query.start - datetime.timedelta(
             days=_MAX_RUNTIME_DAYS)
 
+    current_app.logger.info('DSTAT_PARAMS "%s"', dstat_params)
     jobs = execute_redirect_stdout(lambda: dstat.lookup_job_tasks(
         provider=provider,
         statuses=dstat_params['statuses'],
         user_ids=dstat_params.get('user_ids'),
         job_ids=dstat_params.get('job_ids'),
         task_ids=dstat_params.get('task_ids'),
+        task_attempts=dstat_params.get('task_attempts'),
         create_time_min=create_time_min,
         create_time_max=create_time_max,
         job_names=dstat_params.get('job_names'),
@@ -122,9 +125,10 @@ def generate_jobs_by_window(provider, project_id, window_min, window_max=None):
         yield job
 
 
-def _query_jobs_result(job, project_id=None):
+def _query_jobs_result(job, project_id=''):
     return QueryJobsResult(
-        id=job_ids.dsub_to_api(project_id, job['job-id'], job.get('task-id')),
+        id=job_ids.dsub_to_api(project_id, job['job-id'], job.get(
+            'task-id', ''), job.get('task-attempt', '')),
         name=job['job-name'],
         status=job_statuses.dsub_to_api(job),
         # The LocalJobProvider returns create-time with millisecond granularity.

--- a/servers/dsub/jobs/controllers/utils/labels.py
+++ b/servers/dsub/jobs/controllers/utils/labels.py
@@ -12,4 +12,6 @@ def dsub_to_api(job):
         labels['job-id'] = job['job-id']
     if 'task-id' in job:
         labels['task-id'] = job['task-id']
+    if 'task-attempt' in job:
+        labels['attempt'] = job['task-attempt']
     return labels

--- a/servers/dsub/jobs/controllers/utils/query_parameters.py
+++ b/servers/dsub/jobs/controllers/utils/query_parameters.py
@@ -28,10 +28,12 @@ def api_to_dsub(query):
             dstat_params['job_ids'] = {query.labels['job-id']}
         if query.labels.get('task-id'):
             dstat_params['task_ids'] = {query.labels['task-id']}
+        if query.labels.get('attempt'):
+            dstat_params['task_attempts'] = {query.labels['attempt']}
         dstat_params['labels'] = {
             job_model.LabelParam(k, v)
             for (k, v) in query.labels.items()
-            if k not in ['job-id', 'task-id']
+            if k not in ['job-id', 'task-id', 'attempt']
         }
     if query.submission:
         dstat_params['create_time'] = query.submission

--- a/servers/dsub/jobs/test/base_test_cases.py
+++ b/servers/dsub/jobs/test/base_test_cases.py
@@ -87,8 +87,9 @@ class BaseTestCases:
 
         def api_job_id(self, dsub_job):
             return job_ids.dsub_to_api(self.testing_project,
-                                       dsub_job.get('job-id'),
-                                       dsub_job.get('task-id'))
+                                       dsub_job['job-id'],
+                                       dsub_job.get('task-id', ''),
+                                       dsub_job.get('task-attempt', ''))
 
         def job_has_status(self, job, status):
             return job.status == status


### PR DESCRIPTION
Added a new "Attempt" column for the dsub job manager. Also supports querying by attempt, and now doesn't break when you try to see the details page for a retried job.