### PR TITLE
Move user docs into ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _This product is in Alpha and not yet ready for production use. We welcome all f
 
 Welcome to the Job Manager repository! If you're a developer you're in the right place.
 
-However, if you just want to try out or deploy Job Manager, you will probably find our user and deployment focussed content in
+However, if you just want to try out or deploy Job Manager, you will probably find our user and deployment focused content in
 our ReadTheDocs pages: https://data-biosphere-job-manager.readthedocs.io/en/latest/
 
 ### Try it out, NOW!

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _This product is in Alpha and not yet ready for production use. We welcome all f
 Welcome to the Job Manager repository! If you're a developer you're in the right place.
 
 However, if you just want to try out or deploy Job Manager, you will probably find our user and deployment focussed content in
-our ReadTheDocs pages: https://data-biosphere-job-manager.readthedocs.io/en/stable/
+our ReadTheDocs pages: https://data-biosphere-job-manager.readthedocs.io/en/latest/
 
 ### Try it out, NOW!
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 _This product is in Alpha and not yet ready for production use. We welcome all feedback!_
 
+## User facing documentation
+
+Welcome to the Job Manager repository! If you're a developer you're in the right place.
+
+However, if you just want to try out or deploy Job Manager, you will probably find more tailored content in
+our ReadTheDocs pages: https://databiospherejobmanager.readthedocs.io/en/stable/
 
 ## Try it out!
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,13 @@ _This product is in Alpha and not yet ready for production use. We welcome all f
 
 Welcome to the Job Manager repository! If you're a developer you're in the right place.
 
-However, if you just want to try out or deploy Job Manager, you will probably find more tailored content in
-our ReadTheDocs pages: https://databiospherejobmanager.readthedocs.io/en/stable/
+However, if you just want to try out or deploy Job Manager, you will probably find our user and deployment focussed content in
+our ReadTheDocs pages: https://data-biosphere-job-manager.readthedocs.io/en/stable/
 
-## Try it out!
+### Try it out, NOW!
 
-This script is not perfect but you should be able to get started by copying the following command into a terminal window and following the prompts:
-`
-curl -s https://raw.githubusercontent.com/DataBiosphere/job-manager/master/deploy/quickstart/quick_start.py > /tmp/jmui.py && python3 /tmp/jmui.py
-`
-
-Note: This quickstart script relies on the following being available before starting:
-
-- Linux or MacOS based system
-- Python 3
-- docker
-- docker-compose
-- ifconfig (to provide a hint about your IP address)
-
+The easiest way to try out Job Manager is to use the [getting started script](https://data-biosphere-job-manager.readthedocs.io/en/stable/GettingStarted/QuickStart)
+ 
 ## Welcome
 
 See the [development guide](#development) below.

--- a/docs/GettingStarted/QuickStart.md
+++ b/docs/GettingStarted/QuickStart.md
@@ -1,0 +1,22 @@
+# Trying Job Manager using the QuickStart script
+
+Using this script lets you get started with Job Manager using a single command!
+
+## Prerequisites
+
+The `quick_start.py` script relies on the following being available before starting:
+
+- Linux or MacOS based system
+- Python 3
+- docker
+- docker-compose
+- ifconfig (to provide a hint about your IP address)
+
+## Run the Command!
+ 
+Simply copy the following command into a terminal window and following the prompts:
+`
+curl -s https://raw.githubusercontent.com/DataBiosphere/job-manager/master/deploy/quickstart/quick_start.py > /tmp/jmui.py && python3 /tmp/jmui.py
+`
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,5 +10,7 @@ pages are intended to help you to:
 - Get started with Job Manager!
 - Learn how to deploy in a variety of situations
 
-The easiest way to get started with Job Manager is to use the [quick start command](GettingStarted/QuickStart.md)!
+## Quick Start
+
+**The easiest way to get started with Job Manager is to use the [quick start command](GettingStarted/QuickStart.md)!**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,20 +10,5 @@ pages are intended to help you to:
 - Get started with Job Manager!
 - Learn how to deploy in a variety of situations
 
-The easiest way to get started is to use the quick-start script!
-
-## Try it out!
-
-This script is not perfect but you should be able to get started by copying the following command into a terminal window and following the prompts:
-`
-curl -s https://raw.githubusercontent.com/DataBiosphere/job-manager/master/deploy/quickstart/quick_start.py > /tmp/jmui.py && python3 /tmp/jmui.py
-`
-
-Note: This quickstart script relies on the following being available before starting:
-
-- Linux or MacOS based system
-- Python 3
-- docker
-- docker-compose
-- ifconfig (to provide a hint about your IP address)
+The easiest way to get started with Job Manager is to use the [quick start command](GettingStarted/QuickStart.md)!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,4 @@
-# Job Manager
-
-## Welcome
+# Welcome to Job Manager!
 
 Welcome to our user-facing documentation for Job Manager!
 
@@ -10,7 +8,12 @@ pages are intended to help you to:
 - Get started with Job Manager!
 - Learn how to deploy in a variety of situations
 
-## Quick Start
+# Quickest Start
+
+- Already have a Cromwell or dsub installation?
+- Want to set up and try JMUI immediately? 
+
+Good news!
 
 **The easiest way to get started with Job Manager is to use the [quick start command](GettingStarted/QuickStart.md)!**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# Job Manager
+
+## Welcome
+
+Welcome to our user-facing documentation for Job Manager!
+
+The github repository documentation is pretty heavily biased towards developers, these
+pages are intended to help you to:
+
+- Get started with Job Manager!
+- Learn how to deploy in a variety of situations
+
+The easiest way to get started is to use the quick-start script!
+
+## Try it out!
+
+This script is not perfect but you should be able to get started by copying the following command into a terminal window and following the prompts:
+`
+curl -s https://raw.githubusercontent.com/DataBiosphere/job-manager/master/deploy/quickstart/quick_start.py > /tmp/jmui.py && python3 /tmp/jmui.py
+`
+
+Note: This quickstart script relies on the following being available before starting:
+
+- Linux or MacOS based system
+- Python 3
+- docker
+- docker-compose
+- ifconfig (to provide a hint about your IP address)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: Data Biosphere Job Manager
+site_url: https://github.com/DataBiosphere/job-manager
+site_description: Data Biosphere Job Manager Documentation
+site_author: Data Biosphere
+
+repo_url: https://github.com/DataBiosphere/job-manager
+
+pages:
+- Introduction: index.md
+
+theme: readthedocs
+
+extra_css:
+    - css/extra.css
+extra_javascript:
+    - js/extra.js
+
+# copyright: Copyright &copy; 2017 <a href="https://broadinstitute.org">Broad Institute</a>
+# google_analytics: ['identifierID', 'URL.org']

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,9 @@ site_author: Data Biosphere
 repo_url: https://github.com/DataBiosphere/job-manager
 
 pages:
-- Introduction: index.md
+- Welcome: index.md
+- Getting Started:
+  - Quick Start Script: GettingStarted/QuickStart.md
 
 theme: readthedocs
 


### PR DESCRIPTION
It's a little clunky to have our user and developer docs overlapping - let's use readthedocs to host our user- and deployer-facing documentation in a slightly less intimidating place?

This one works:
- Current content: https://data-biosphere-job-manager.readthedocs.io/en/cjl_rtd/

These will work when we make a commit to master and/or a new tag:
- Master branch: https://data-biosphere-job-manager.readthedocs.io/en/latest/
- Tagged branch: https://data-biosphere-job-manager.readthedocs.io/en/stable/