### PR TITLE
Pin to older version of tox to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,9 @@ jobs:
             /bin/bash ./scripts/rebuild_swagger.sh
       - run:
           name: Install detox and yapf
+          # detox fails with newer versions of tox: https://github.com/tox-dev/detox/issues/33
           command: |
-            pip install detox yapf
+            pip install detox tox==3.4.0 yapf
       - run:
           name: Lint python code with yapf
           command: |


### PR DESCRIPTION
https://github.com/tox-dev/detox/issues/33

Debug process:
- Search Google/tox for issues mentioning this, didn't find any
- Compare circle outputs from the failing vs successful runs, particularly the versions installed in the step "Install detox and yapf"
- Rerun with SSH - SSH into Circle to reproduce the issue
- Noticed different tox version installed across runs, try downgrading to 3.4.0 (last working version)
- Ran the tests again and verified this fixes
- Realized this repros with detox but not tox alone, looked at detox repo and found the issue: https://github.com/tox-dev/detox/issues/33