### PR TITLE
Hide boolean query extensions from query builder

### DIFF
--- a/ui/src/app/shared/utils/url-search-params.utils.ts
+++ b/ui/src/app/shared/utils/url-search-params.utils.ts
@@ -162,7 +162,7 @@ import {TimeFrame} from "../model/TimeFrame";
         if (!queryExtensionsDataTypes.has(field)) {
           throw new Error("Unsupported queryExtension field.")
         }
-        if (field != 'hideArchived') {
+        if (queryExtensionsDataTypes.get(field) != FieldDataType.Boolean) {
           queryFields.set(field, queryExtensionsDataTypes.get(field));
         }
       });

--- a/ui/src/app/shared/utils/url-search-params.utils.ts
+++ b/ui/src/app/shared/utils/url-search-params.utils.ts
@@ -162,7 +162,9 @@ import {TimeFrame} from "../model/TimeFrame";
         if (!queryExtensionsDataTypes.has(field)) {
           throw new Error("Unsupported queryExtension field.")
         }
-        queryFields.set(field, queryExtensionsDataTypes.get(field));
+        if (field != 'hideArchived') {
+          queryFields.set(field, queryExtensionsDataTypes.get(field));
+        }
       });
     }
 


### PR DESCRIPTION
I realized that, without this change, the `hideArchived` query extension will show up as an option in the query builder.  This change filters out any `boolean` query extensions from the menu.