### PR TITLE
fix for whitespace in label values

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -247,7 +247,8 @@ def query_jobs(body, **kwargs):
     auth = kwargs.get('auth')
     headers = kwargs.get('auth_headers')
     query = QueryJobsRequest.from_dict(body)
-    query.labels = _format_query_labels(query.labels)
+    if query.labels is not None:
+        query.labels = _format_query_labels(query.labels)
     query_page_size = query.page_size or _DEFAULT_PAGE_SIZE
     offset = 0
     if query.page_token is not None:

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -247,8 +247,7 @@ def query_jobs(body, **kwargs):
     auth = kwargs.get('auth')
     headers = kwargs.get('auth_headers')
     query = QueryJobsRequest.from_dict(body)
-    if query.labels is not None:
-        query.labels = _format_query_labels(query.labels)
+    query.labels = _format_query_labels(query.labels)
     query_page_size = query.page_size or _DEFAULT_PAGE_SIZE
     offset = 0
     if query.page_token is not None:
@@ -373,7 +372,9 @@ def _get_base_url():
 
 
 def _format_query_labels(orig_query_labels):
+    if orig_query_labels is None:
+        return None
     query_labels = {}
     for key, val in orig_query_labels.items():
-        query_labels[key] = urllib.unquote(val).decode('utf8')
+        query_labels[urllib.unquote(key)] = urllib.unquote(val)
     return query_labels

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -17,6 +17,7 @@ from jobs.models.update_job_labels_response import UpdateJobLabelsResponse
 from jobs.models.update_job_labels_request import UpdateJobLabelsRequest
 from jobs.controllers.utils import job_statuses
 from jobs.controllers.utils import task_statuses
+import urllib
 
 _DEFAULT_PAGE_SIZE = 64
 
@@ -246,6 +247,7 @@ def query_jobs(body, **kwargs):
     auth = kwargs.get('auth')
     headers = kwargs.get('auth_headers')
     query = QueryJobsRequest.from_dict(body)
+    query.labels = _format_query_labels(query.labels)
     query_page_size = query.page_size or _DEFAULT_PAGE_SIZE
     offset = 0
     if query.page_token is not None:
@@ -367,3 +369,10 @@ def _parse_datetime(date_string):
 
 def _get_base_url():
     return current_app.config['cromwell_url']
+
+
+def _format_query_labels(orig_query_labels):
+    query_labels = {}
+    for key, val in orig_query_labels.items():
+        query_labels[key] = urllib.unquote(val).decode('utf8')
+    return query_labels

--- a/ui/src/app/shared/utils/url-search-params.utils.ts
+++ b/ui/src/app/shared/utils/url-search-params.utils.ts
@@ -143,7 +143,7 @@ import {TimeFrame} from "../model/TimeFrame";
     let chips: Map<string, string> = new Map();
     urlSearchParams.paramsMap.forEach((values: string[], key: string) => {
       if (values && key) {
-        chips.set(key, values.toString());
+        chips.set(key, decodeURIComponent(values.toString()));
       }
     });
     return chips;

--- a/ui/src/app/shared/utils/url-search-params.utils.ts
+++ b/ui/src/app/shared/utils/url-search-params.utils.ts
@@ -143,7 +143,7 @@ import {TimeFrame} from "../model/TimeFrame";
     let chips: Map<string, string> = new Map();
     urlSearchParams.paramsMap.forEach((values: string[], key: string) => {
       if (values && key) {
-        chips.set(key, decodeURIComponent(values.toString()));
+        chips.set(decodeURIComponent(key), decodeURIComponent(values.toString()));
       }
     });
     return chips;


### PR DESCRIPTION
Filtering by a label value with whitespace in it currently doesn't work. I added URL decoding to the UI and Cromwell shim layer.