### PR TITLE
Improve usability of query builder

### DIFF
--- a/ui/src/app/shared/header/chips/filter-chip.component.html
+++ b/ui/src/app/shared/header/chips/filter-chip.component.html
@@ -11,7 +11,7 @@
   <mat-form-field *ngSwitchCase="'Text'" class="query-input">
     <!--Free text input-->
     <input matInput #freeTextInput
-           placeholder="Equals"
+           placeholder="{{ chipKey | titlecase }} equals"
            type="search"
            [(ngModel)]="currentChipValue"
            value="{{currentChipValue}}"

--- a/ui/src/app/shared/header/header.component.css
+++ b/ui/src/app/shared/header/header.component.css
@@ -1,9 +1,33 @@
 .content {
   margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .query-form {
-  width: 100%;
+  width: 60%;
+  min-width: 60rem;
+  padding-top: 0.5rem;
+  line-height: 1.5rem;
+}
+
+::ng-deep .query-form .mat-input-flex.mat-form-field-flex {
+  margin-top: 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+::ng-deep .query-form .mat-input-infix {
+  padding-top: 0.5rem;
+  border-top: none;
+  padding-bottom: 0.3rem;
+}
+
+::ng-deep .mat-form-field-can-float.mat-form-field-should-float.query-form .mat-form-field-label {
+  display: none;
+}
+
+.query-form clr-icon {
+  vertical-align: top;
+  padding: 0 0.5rem;
 }
 
 .search-button {
@@ -19,6 +43,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  min-width: 60rem;
 }
 
 .chipShell {

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -1,5 +1,6 @@
 <div class="content">
   <mat-form-field class="query-form">
+    <span matPrefix><clr-icon shape="filter-2" size="18" style="color: #888"></clr-icon></span>
     <mat-chip-list #chipList>
       <mat-chip
         *ngFor="let chipKey of getChipKeys()"
@@ -13,7 +14,7 @@
           (removeChip)="removeChip(chipKey)">
         </jm-filter-chip>
       </mat-chip>
-      <input matInput
+      <input matInput placeholder="Filter jobs"
              [(ngModel)]="inputValue"
              value="{{inputValue}}"
              [matAutocomplete]="auto"
@@ -31,9 +32,6 @@
         </mat-option>
       </mat-autocomplete>
     </mat-chip-list>
-    <button mat-icon-button matSuffix class="search-button" (click)="search()">
-      <img src="https://www.gstatic.com/images/icons/material/system/1x/search_grey600_24dp.png">
-    </button>
   </mat-form-field>
 
   <div *ngIf="showControls" class="search-table-controls">

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -17,6 +17,7 @@ import {
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {RouterTestingModule} from "@angular/router/testing";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {ClrIconModule} from '@clr/angular';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 import {CapabilitiesService} from "../../core/capabilities.service"
@@ -62,6 +63,7 @@ describe('HeaderComponent', () => {
       declarations: [HeaderComponent, TestHeaderComponent, MockFilterChipComponent],
       imports: [
         BrowserAnimationsModule,
+        ClrIconModule,
         FormsModule,
         MatAutocompleteModule,
         MatButtonModule,

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -18,6 +18,7 @@ import {
   MatNativeDateModule,
   MatPaginatorModule,
 } from "@angular/material";
+import {ClrIconModule} from '@clr/angular';
 import {HeaderComponent} from "./header/header.component";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {FilterChipComponent} from "./header/chips/filter-chip.component";
@@ -26,6 +27,7 @@ import {DatepickerInputComponent} from "./header/chips/datepicker-input.componen
 
 @NgModule({
   imports: [
+    ClrIconModule,
     CommonModule,
     FormsModule,
     MatAutocompleteModule,


### PR DESCRIPTION
Addresses issues brought up in usability testing:
-  Filter icon instead of magnifying glass
-  Make sure suggestion appears whenever field has focus
-  Border all four sides
-  Prompt text (possibly something generic like Filter Workflows)

before:
![query-builder-before](https://user-images.githubusercontent.com/1713505/48284247-e0710f80-e42c-11e8-9462-a615e898d8ea.png)

after:
![screen shot 2018-11-09 at 2 36 56 pm](https://user-images.githubusercontent.com/1713505/48284422-61c8a200-e42d-11e8-85d8-ef9f7f6e5e0f.png)

Closes #510 