### PR TITLE
Make job/task status icons more intuitive

### DIFF
--- a/ui/src/app/job-details/tasks/tasks.component.css
+++ b/ui/src/app/job-details/tasks/tasks.component.css
@@ -74,6 +74,14 @@ clr-tooltip-content {
   height: auto;
 }
 
+::ng-deep .shards-menu.mat-menu-panel {
+  overflow: visible;
+}
+
+::ng-deep .shards-menu.mat-menu-panel clr-tooltip-content {
+  margin-right: 0.25rem;
+}
+
 clr-icon {
   margin-right: 1rem;
 }

--- a/ui/src/app/job-details/tasks/tasks.component.html
+++ b/ui/src/app/job-details/tasks/tasks.component.html
@@ -24,11 +24,18 @@
                 </clr-tooltip-content>
               </clr-tooltip>
             </button>
-            <mat-menu #shardMenu="matMenu" class="wide-menu" xPosition="after" yPosition="below" [overlapTrigger]="false">
+            <mat-menu #shardMenu="matMenu" class="wide-menu shards-menu" xPosition="after" yPosition="below" [overlapTrigger]="false">
               <div class="shards-header">Scattered: {{ getScatteredCountTotal(t) }} shards</div>
               <div class="shards-container" *ngIf="t.shardStatuses">
                 <div class="shards-statuses" *ngFor="let jobStatus of getShardStatuses()">
-                  <div class="shard-status"><clr-icon [attr.shape]="getStatusIcon(jobStatus)" size="18"></clr-icon></div>
+                  <div class="shard-status">
+                    <clr-tooltip>
+                      <clr-icon clrTooltipTrigger [attr.shape]="getStatusIcon(jobStatus)" size="18"></clr-icon>
+                      <clr-tooltip-content clrPosition="left"  clrSize="xs" *clrIfOpen>
+                        <span>{{ jobStatus }}</span>
+                      </clr-tooltip-content>
+                    </clr-tooltip>
+                  </div>
                   <div class="shard-count">{{ getShardCountByStatus(t, jobStatus) }}</div>
                 </div>
               </div>

--- a/ui/src/app/job-details/tasks/tasks.component.spec.ts
+++ b/ui/src/app/job-details/tasks/tasks.component.spec.ts
@@ -92,7 +92,7 @@ describe('TaskDetailsComponent', () => {
     expect(de.query(By.css('.title-link')).nativeElement.href)
       .toContain('/jobs/' + task.jobId);
     expect(de.query(By.css('.mat-column-status clr-icon')).attributes['shape'])
-      .toContain('times');
+      .toContain('error');
     expect(de.queryAll(By.css('.mat-column-startTime'))[1].nativeElement.textContent)
       .toContain('1:00 PM');
     expect(de.queryAll(By.css('.mat-column-duration'))[1].nativeElement.textContent)

--- a/ui/src/app/shared/common.ts
+++ b/ui/src/app/shared/common.ts
@@ -10,8 +10,8 @@ export enum JobStatusIcon {
   Submitted = 'minus',
   Running = 'sync',
   Aborting = 'sync',
-  Failed = 'exclamation-circle',
-  Succeeded = 'check-circle',
+  Failed = 'error-standard',
+  Succeeded = 'success-standard',
   Aborted = 'times-circle',
   OnHold = 'minus-circle'
 }

--- a/ui/src/app/shared/common.ts
+++ b/ui/src/app/shared/common.ts
@@ -9,11 +9,11 @@ export const STORAGE_REF = 'storage-ref';
 export enum JobStatusIcon {
   Submitted = 'minus',
   Running = 'sync',
-  Aborting = 'exclamation-triangle',
-  Failed = 'times',
-  Succeeded = 'check',
-  Aborted = 'exclamation-triangle',
-  OnHold = 'pause'
+  Aborting = 'sync',
+  Failed = 'exclamation-circle',
+  Succeeded = 'check-circle',
+  Aborted = 'times-circle',
+  OnHold = 'minus-circle'
 }
 
 // TODO(bryancrampton): We may want to move this to be part of


### PR DESCRIPTION
- change the `aborted`, `aborting`, `failed`, `on hold`, and `succeeded` icons in response to user testing
- added tooltips for shard status icons

![screen shot 2018-11-16 at 4 16 29 pm](https://user-images.githubusercontent.com/1713505/48647951-969fa080-e9bb-11e8-8302-775dc24176b9.png)

Closes #517