### PR TITLE
set different filter behavior for status checkboxes

### DIFF
--- a/ui/src/app/shared/header/chips/filter-chip.component.ts
+++ b/ui/src/app/shared/header/chips/filter-chip.component.ts
@@ -74,8 +74,11 @@ export class FilterChipComponent implements OnInit {
   }
 
   setChipValue(value: string): void {
+    console.log(this.getCurrentChipType());
     if (value) {
-      this.chipMenuTrigger.closeMenu();
+      if (this.getCurrentChipType() != 'Status') {
+        this.chipMenuTrigger.closeMenu();
+      }
       this.currentChipValue = value;
       this.updateValue.emit(this.currentChipValue);
     }

--- a/ui/src/app/shared/header/chips/filter-chip.component.ts
+++ b/ui/src/app/shared/header/chips/filter-chip.component.ts
@@ -74,7 +74,6 @@ export class FilterChipComponent implements OnInit {
   }
 
   setChipValue(value: string): void {
-    console.log(this.getCurrentChipType());
     if (value) {
       if (this.getCurrentChipType() != 'Status') {
         this.chipMenuTrigger.closeMenu();


### PR DESCRIPTION
Because a user can select multiple statuses to filter the job list by, change the `click` behavior so that the user can do so without having to choose `statuses` from the query builder menu each time.

Closes #437