### PR TITLE
Make filter options consistent with the job list columns

### DIFF
--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -362,7 +362,7 @@ definitions:
         format: date-time
         description: >
           Returns only jobs with an equal or later submission datetime.
-      statuses:
+      status:
         type: array
         items:
           $ref: '#/definitions/JobStatus'

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -318,10 +318,10 @@ def cromwell_query_params(query, page, page_size):
         query_params.append({'submission': submission})
     if query.name:
         query_params.append({'name': query.name})
-    if query.statuses:
+    if query.status:
         statuses = [{
             'status': job_statuses.api_workflow_status_to_cromwell(s)
-        } for s in set(query.statuses)]
+        } for s in set(query.status)]
         query_params.extend(statuses)
     if query.labels:
         labels = [{'label': k + ':' + v} for k, v in query.labels.items()]

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -663,7 +663,7 @@ class TestJobsController(BaseTestCase):
             start=datetime.strptime('2017-10-30T18:04:47.271Z',
                                     datetime_format),
             end=datetime.strptime('2017-10-31T18:04:47.271Z', datetime_format),
-            statuses=['Submitted', 'Running', 'Succeeded'],
+            status=['Submitted', 'Running', 'Succeeded'],
             labels={
                 'label-key-1': 'label-val-1',
                 'label-key-2': 'label-val-2'
@@ -691,7 +691,7 @@ class TestJobsController(BaseTestCase):
         }, {
             'includeSubworkflows': 'false'
         }]
-        query_params.extend([{'status': s} for s in query.statuses])
+        query_params.extend([{'status': s} for s in query.status])
         self.assertItemsEqual(
             sorted(query_params),
             sorted(jobs_controller.cromwell_query_params(query, 23, 100)))

--- a/servers/dsub/jobs/controllers/utils/jobs_generator.py
+++ b/servers/dsub/jobs/controllers/utils/jobs_generator.py
@@ -55,7 +55,7 @@ def generate_jobs(provider, query, create_time_max=None, offset_id=None):
         job = _query_jobs_result(j, proj_id)
         # Filter pending vs. running jobs since dstat does not have
         # a corresponding status (both RUNNING)
-        if query.statuses and job.status not in query.statuses:
+        if query.status and job.status not in query.status:
             continue
         if query.start and (not job.start or job.start < query.start):
             continue

--- a/servers/dsub/jobs/controllers/utils/query_parameters.py
+++ b/servers/dsub/jobs/controllers/utils/query_parameters.py
@@ -18,8 +18,8 @@ def api_to_dsub(query):
 
     dstat_params['statuses'] = {
         job_statuses.api_to_dsub(s)
-        for s in query.statuses
-    } if query.statuses else {'*'}
+        for s in query.status
+    } if query.status else {'*'}
 
     if query.name:
         dstat_params['job_names'] = {query.name}

--- a/servers/dsub/jobs/test/base_google_test_cases.py
+++ b/servers/dsub/jobs/test/base_google_test_cases.py
@@ -68,13 +68,13 @@ class BaseGoogleTestCases:
         def test_query_jobs_by_submitted_status(self):
             job1 = self.start_job('echo job1 && sleep 30', name='job1')
             self.assert_query_matches(
-                QueryJobsRequest(statuses=[ApiStatus.SUBMITTED]), [job1])
+                QueryJobsRequest(status=[ApiStatus.SUBMITTED]), [job1])
             self.wait_status(self.api_job_id(job1), ApiStatus.RUNNING)
             job2 = self.start_job('echo job2 && sleep 30', name='job2')
             self.assert_query_matches(
-                QueryJobsRequest(statuses=[ApiStatus.SUBMITTED]), [job2])
+                QueryJobsRequest(status=[ApiStatus.SUBMITTED]), [job2])
             self.assert_query_matches(
-                QueryJobsRequest(statuses=[ApiStatus.RUNNING]), [job1])
+                QueryJobsRequest(status=[ApiStatus.RUNNING]), [job1])
 
         def test_query_jobs_by_start(self):
             date = datetime.datetime.now()

--- a/servers/dsub/jobs/test/base_test_cases.py
+++ b/servers/dsub/jobs/test/base_test_cases.py
@@ -320,16 +320,16 @@ class BaseTestCases:
                 'echo RUNNING && sleep 30', name='running')
             self.wait_status(self.api_job_id(running), ApiStatus.RUNNING)
             self.assert_query_matches(
-                QueryJobsRequest(statuses=[ApiStatus.SUCCEEDED]), [succeeded])
+                QueryJobsRequest(status=[ApiStatus.SUCCEEDED]), [succeeded])
             self.assert_query_matches(
-                QueryJobsRequest(statuses=[ApiStatus.RUNNING]), [running])
+                QueryJobsRequest(status=[ApiStatus.RUNNING]), [running])
             self.assert_query_matches(
                 QueryJobsRequest(
-                    statuses=[ApiStatus.RUNNING, ApiStatus.SUCCEEDED]),
+                    status=[ApiStatus.RUNNING, ApiStatus.SUCCEEDED]),
                 [succeeded, running])
             self.assert_query_matches(
                 QueryJobsRequest(
-                    statuses=[ApiStatus.SUCCEEDED, ApiStatus.RUNNING]),
+                    status=[ApiStatus.SUCCEEDED, ApiStatus.RUNNING]),
                 [succeeded, running])
 
         def test_query_jobs_by_label_job_id(self):

--- a/ui/src/app/dashboard/dashboard.component.spec.ts
+++ b/ui/src/app/dashboard/dashboard.component.spec.ts
@@ -219,13 +219,13 @@ describe('DashboardComponent', () => {
     tick();
     const testJobListComponent = de.query(By.css('jm-test-job-list-component')).componentInstance;
     const queryJobRequest = URLSearchParamsUtils.unpackURLSearchParams(testJobListComponent.activatedRoute.snapshot.queryParams['q']);
-    expect(queryJobRequest.statuses).toContain(status);
+    expect(queryJobRequest.status).toContain(status);
     expect(queryJobRequest.extensions['projectId']).toEqual(TEST_PROJECT);
   }));
 
   it('should have status and label as url params when groupedSummaryComponent links are clicked', fakeAsync(() => {
     const groupedSummaryAnchor = de.query(By.css('jm-grouped-summary tr td.count a')).nativeElement;
-    const status: JobStatus= JobStatus.Succeeded;
+    const status: JobStatus = JobStatus.Succeeded;
     const labelKey = TEST_AGGREGATION_RESPONSE.aggregations[0].key;
     const labelValue = TEST_AGGREGATION_RESPONSE.aggregations[0].entries[0].label;
 
@@ -235,7 +235,7 @@ describe('DashboardComponent', () => {
     const testJobListComponent = de.query(By.css('jm-test-job-list-component')).componentInstance;
     const queryJobRequest = URLSearchParamsUtils.unpackURLSearchParams(testJobListComponent.activatedRoute.snapshot.queryParams['q']);
     // this test is based on the hard-coded aggregation response
-    expect(queryJobRequest.statuses).toContain(status);
+    expect(queryJobRequest.status).toContain(status);
     expect(queryJobRequest.labels[labelKey]).toEqual(labelValue);
     expect(queryJobRequest.extensions['projectId']).toEqual(TEST_PROJECT);
   }));

--- a/ui/src/app/dashboard/grouped-summary/grouped-summary.component.ts
+++ b/ui/src/app/dashboard/grouped-summary/grouped-summary.component.ts
@@ -77,7 +77,7 @@ export class GroupedSummaryComponent implements OnInit {
 
   getStatusUrlParams(entry: Map<string, string>, status: JobStatus) {
     let map = this.getCommonUrlParamsMap(entry);
-    map.set('statuses', [status.toString()]);
+    map.set('status', [status.toString()]);
     return {q: URLSearchParamsUtils.encodeURLSearchParamsFromMap(map)};
   }
 

--- a/ui/src/app/dashboard/total-summary/total-summary.component.ts
+++ b/ui/src/app/dashboard/total-summary/total-summary.component.ts
@@ -46,7 +46,7 @@ export class TotalSummaryComponent implements OnInit, OnChanges {
 
   getUrlParams(status: JobStatus) {
     const query = URLSearchParamsUtils.unpackURLSearchParams(this.activatedRoute.snapshot.queryParams['q']);
-    query.statuses = [status];
+    query.status = [status];
 
     const startTime = URLSearchParamsUtils.getStartTimeByTimeFrame(this.timeFrame);
     if (startTime) {

--- a/ui/src/app/shared/common.ts
+++ b/ui/src/app/shared/common.ts
@@ -31,7 +31,7 @@ export enum FieldDataType {
  *  pageSize and pageToken). */
 export const queryDataTypes: Map<string, FieldDataType> = new Map([
   ['name', FieldDataType.Text],
-  ['statuses', FieldDataType.Enum],
+  ['status', FieldDataType.Enum],
   ['start', FieldDataType.Date],
   ['end', FieldDataType.Date],
   ['submission', FieldDataType.Date]

--- a/ui/src/app/shared/header/chips/filter-chip.component.html
+++ b/ui/src/app/shared/header/chips/filter-chip.component.html
@@ -18,7 +18,7 @@
            (keyup.enter)="setChipValue(currentChipValue)"
            (click)="$event.stopPropagation()"/>
   </mat-form-field>
-  <!-- Statuses -->
+  <!-- Status -->
   <jm-status-selection
     *ngSwitchCase="'Status'"
     [initialChipValue]="currentChipValue"

--- a/ui/src/app/shared/header/chips/filter-chip.component.ts
+++ b/ui/src/app/shared/header/chips/filter-chip.component.ts
@@ -47,7 +47,7 @@ export class FilterChipComponent implements OnInit {
   }
 
   getCurrentChipType(): string {
-    if (this.chipKey == 'statuses') {
+    if (this.chipKey == 'status') {
       return 'Status';
     }
     if (this.chipKey && this.options.has(this.chipKey)) {

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -28,7 +28,7 @@
           *ngFor="let option of filteredOptions | async"
           [value]="option"
           (click)="addChip(option)">
-          {{ option }}
+          {{ getDisplayForFilter(option) }}
         </mat-option>
       </mat-autocomplete>
     </mat-chip-list>

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -94,7 +94,7 @@ describe('HeaderComponent', () => {
     testComponent.chips = new Map()
       .set('projectId', 'Project ID')
       .set('name', 'Job Name')
-      .set('statuses', 'Running');
+      .set('status', 'Running');
     fixture.detectChanges();
   }));
 
@@ -118,7 +118,7 @@ describe('HeaderComponent', () => {
   }));
 
   it('should not show status buttons', async(() => {
-    testComponent.chips.set('statuses', 'list,of,statuses');
+    testComponent.chips.set('status', 'list,of,status');
     testComponent.search();
     fixture.detectChanges();
     fixture.whenStable().then(() => {
@@ -128,7 +128,7 @@ describe('HeaderComponent', () => {
   }));
 
   it('should show status buttons', async(() => {
-    testComponent.chips.delete('statuses');
+    testComponent.chips.delete('status');
     testComponent.search();
     fixture.detectChanges();
     fixture.whenStable().then(() => {
@@ -138,7 +138,7 @@ describe('HeaderComponent', () => {
   }));
 
   it('should show status counts', async(() => {
-    testComponent.chips.delete('statuses');
+    testComponent.chips.delete('status');
     testComponent.jobs.next({
       results: [testJob1, testJob2],
       totalSize: undefined,
@@ -155,7 +155,7 @@ describe('HeaderComponent', () => {
   }));
 
   it('should show hide status counts on non-exhaustive', async(() => {
-    testComponent.chips.delete('statuses');
+    testComponent.chips.delete('status');
     testComponent.jobs.next({
       results: [testJob1, testJob2],
       totalSize: undefined,
@@ -209,7 +209,7 @@ describe('HeaderComponent', () => {
   }));
 
   it('should maintain chip ordering', fakeAsync(() => {
-    testComponent.chips.delete('statuses');
+    testComponent.chips.delete('status');
     testComponent.search();
     fixture.detectChanges();
     tick();
@@ -219,7 +219,7 @@ describe('HeaderComponent', () => {
     tick();
     fixture.detectChanges();
     const lastFilter = de.queryAll(By.css('jm-filter-chip'))[2].componentInstance;
-    expect(lastFilter.chipKey).toEqual('statuses');
+    expect(lastFilter.chipKey).toEqual('status');
   }));
 
   @Component({

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -18,6 +18,7 @@ import {FormControl} from '@angular/forms';
 import {ActivatedRoute, Router} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
+import {TitleCasePipe} from '@angular/common';
 import {
   MatAutocompleteTrigger,
   MatPaginator,
@@ -61,6 +62,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   private readonly completedStatuses = [JobStatus.Succeeded];
   private readonly failedStatuses = [JobStatus.Failed, JobStatus.Aborted];
   private readonly onHoldStatuses = [JobStatus.OnHold];
+  private readonly capabilties: CapabilitiesResponse;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -70,6 +72,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
     private cdr: ChangeDetectorRef,
   ) {
     route.queryParams.subscribe(params => this.refreshChips(params['q']));
+    this.capabilties = this.capabilitiesService.getCapabilitiesSynchronous();
   }
 
   ngOnInit(): void {
@@ -77,7 +80,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
       this.chips = URLSearchParamsUtils.getChips(this.route.snapshot.queryParams['q']);
     }
 
-    this.options = URLSearchParamsUtils.getQueryFields(this.capabilitiesService.getCapabilitiesSynchronous());
+    this.options = URLSearchParamsUtils.getQueryFields(this.capabilties);
     this.filterOptions();
   }
 
@@ -161,6 +164,19 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
 
   getChipKeys(): string[] {
     return Array.from(this.chips.keys());
+  }
+
+  getDisplayForFilter(value: string): string {
+    const displayField = this.capabilties.displayFields.find((f) => f.field == value);
+    if (displayField && displayField.display) {
+      return displayField.display;
+    }
+    const labelField = this.capabilties.displayFields.find((f) => f.field == 'labels.' + value);
+    if (labelField && labelField.display) {
+      return labelField.display;
+    }
+    const titleCasePipe: TitleCasePipe = new TitleCasePipe();
+    return titleCasePipe.transform(value);
   }
 
   navigateWithStatus(statuses: JobStatus[]): void {

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -62,7 +62,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   private readonly completedStatuses = [JobStatus.Succeeded];
   private readonly failedStatuses = [JobStatus.Failed, JobStatus.Aborted];
   private readonly onHoldStatuses = [JobStatus.OnHold];
-  private readonly capabilties: CapabilitiesResponse;
+  private readonly capabilities: CapabilitiesResponse;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -72,7 +72,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
     private cdr: ChangeDetectorRef,
   ) {
     route.queryParams.subscribe(params => this.refreshChips(params['q']));
-    this.capabilties = this.capabilitiesService.getCapabilitiesSynchronous();
+    this.capabilities = this.capabilitiesService.getCapabilitiesSynchronous();
   }
 
   ngOnInit(): void {
@@ -80,7 +80,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
       this.chips = URLSearchParamsUtils.getChips(this.route.snapshot.queryParams['q']);
     }
 
-    this.options = URLSearchParamsUtils.getQueryFields(this.capabilties);
+    this.options = URLSearchParamsUtils.getQueryFields(this.capabilities);
     this.filterOptions();
   }
 
@@ -167,11 +167,11 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   }
 
   getDisplayForFilter(value: string): string {
-    const displayField = this.capabilties.displayFields.find((f) => f.field == value);
+    const displayField = this.capabilities.displayFields.find((f) => f.field == value);
     if (displayField && displayField.display) {
       return displayField.display;
     }
-    const labelField = this.capabilties.displayFields.find((f) => f.field == 'labels.' + value);
+    const labelField = this.capabilities.displayFields.find((f) => f.field == 'labels.' + value);
     if (labelField && labelField.display) {
       return labelField.display;
     }
@@ -180,7 +180,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   }
 
   navigateWithStatus(statuses: JobStatus[]): void {
-    this.chips.set('statuses', statuses.map((status) => JobStatus[status]).join(','));
+    this.chips.set('status', statuses.map((status) => JobStatus[status]).join(','));
     this.search();
   }
 
@@ -217,7 +217,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
 
   shouldDisplayStatusButtons(): boolean {
     return !URLSearchParamsUtils.unpackURLSearchParams(
-      this.route.snapshot.queryParams['q'])['statuses'];
+      this.route.snapshot.queryParams['q'])['status'];
   }
 
   shouldDisplayStatusCounts(): boolean {

--- a/ui/src/app/shared/utils/url-search-params-utils.spec.ts
+++ b/ui/src/app/shared/utils/url-search-params-utils.spec.ts
@@ -5,21 +5,21 @@ import {QueryJobsRequest} from "../model/QueryJobsRequest";
 
 const queryRequest: QueryJobsRequest = {
   name: 'job-name',
-  statuses: [JobStatus.Running, JobStatus.Aborted],
+  status: [JobStatus.Running, JobStatus.Aborted],
   labels: {'key': 'value'},
   extensions: {
     projectId: 'project-id'
   }
 };
-const queryRequestString: string = 'statuses=Running&statuses=Aborted&name=job-name&projectId=project-id&key=value';
+const queryRequestString: string = 'status=Running&status=Aborted&name=job-name&projectId=project-id&key=value';
 
 const queryMap:  Map<String, String[]> = new Map()
   .set('name', ['job-name'])
-  .set('statuses', ['Running', 'Aborted'])
+  .set('status', ['Running', 'Aborted'])
   .set('key', ['value'])
   .set('projectId', ['project-id']);
 
-const queryMapString: string = 'name=job-name&statuses=Running&statuses=Aborted&key=value&projectId=project-id';
+const queryMapString: string = 'name=job-name&status=Running&status=Aborted&key=value&projectId=project-id';
 
 describe('URLSearchParamsUtils', () => {
   beforeEach(async(() => {
@@ -45,7 +45,7 @@ describe('URLSearchParamsUtils', () => {
     let actualRequest: QueryJobsRequest = URLSearchParamsUtils.unpackURLSearchParams(queryRequestString);
     expect(actualRequest.extensions.projectId).toBe(queryRequest.extensions.projectId);
     expect(actualRequest.name).toBe(queryRequest.name);
-    expect(actualRequest.statuses.toString()).toBe(queryRequest.statuses.toString());
+    expect(actualRequest.status.toString()).toBe(queryRequest.status.toString());
     expect(actualRequest.labels['key']).toBe(queryRequest.labels['key']);
   });
 

--- a/ui/src/app/shared/utils/url-search-params.utils.ts
+++ b/ui/src/app/shared/utils/url-search-params.utils.ts
@@ -14,8 +14,8 @@ export class URLSearchParamsUtils {
   public static encodeURLSearchParams(request: QueryJobsRequest): string {
     let urlSearchParams = new URLSearchParams();
 
-    for (let s in request.statuses) {
-      urlSearchParams.append('statuses', JobStatus[request.statuses[s]]);
+    for (let s in request.status) {
+      urlSearchParams.append('status', JobStatus[request.status[s]]);
     }
     if (request.name) {
       urlSearchParams.set('name', request.name);

--- a/ui/src/app/testing/fake-job-manager.service.ts
+++ b/ui/src/app/testing/fake-job-manager.service.ts
@@ -58,11 +58,11 @@ export class FakeJobManagerService extends JobManagerService {
   }
 
   queryJobs(req: QueryJobsRequest): Promise<QueryJobsResponse> {
-    const statuses: Set<JobStatus> = new Set(req.statuses);
+    const statuses: Set<JobStatus> = new Set(req.status);
     return Promise.resolve({
       results: this.jobs
         .filter(j => {
-          if (req.statuses) {
+          if (req.status) {
             return statuses.has(j.status);
           }
           return true;


### PR DESCRIPTION
In response to user testing results, make the options in the query builder filter drop down correspond to the column headings in the job listing.

Closes #520 