### PR TITLE
small design changes to job details menu

### DIFF
--- a/ui/src/app/job-list/table/table.component.css
+++ b/ui/src/app/job-list/table/table.component.css
@@ -95,10 +95,6 @@
   padding-left: 0;
 }
 
-::ng-deep .mat-menu-panel {
-  max-width: inherit;
-}
-
 ::ng-deep .mat-menu-panel.details-menu .mat-card {
   box-shadow: none;
   border-bottom: none;
@@ -108,6 +104,10 @@
 ::ng-deep .mat-menu-panel.details-menu mat-card a {
   display: block;
   cursor: pointer;
+  max-width: 210px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 ::ng-deep .mat-menu-panel.details-menu mat-card a,

--- a/ui/src/app/job-list/table/table.component.html
+++ b/ui/src/app/job-list/table/table.component.html
@@ -65,10 +65,15 @@
                 </a>
               </mat-list-item>
               <mat-list-item *ngIf="j.name">
-                <a (click)="filterOnFieldValue('name', j.name)">
-                  <clr-icon shape="filter-2" size="24"></clr-icon>
-                  <span>Filter by <strong>name:{{ j.name }}</strong></span>
-                </a>
+                  <clr-tooltip>
+                    <a (click)="filterOnFieldValue('name', j.name)" clrTooltipTrigger>
+                      <clr-icon shape="filter-2" size="24"></clr-icon>
+                      <span class="job-title-filter">Filter by name:{{ j.name }}</span>
+                      <clr-tooltip-content clrPosition="top-right" clrSize="xs" *clrIfOpen>
+                        <span>Filter by name:{{ j.name }}</span>
+                      </clr-tooltip-content>
+                    </a>
+                  </clr-tooltip>
               </mat-list-item>
             </mat-list>
           </mat-card-actions>


### PR DESCRIPTION
After discussion with the designer and the product manager, implemented small changes to task details page:

Before:
![screen shot 2018-11-14 at 5 03 28 pm](https://user-images.githubusercontent.com/1713505/48516030-5f50b880-e830-11e8-90e1-04ba1ea573f7.png)

After:
![screen shot 2018-11-20 at 1 35 30 pm](https://user-images.githubusercontent.com/1713505/48794932-69a80200-ecc9-11e8-958c-a6857088f0e2.png) ![screen shot 2018-11-20 at 1 36 57 pm](https://user-images.githubusercontent.com/1713505/48795031-bbe92300-ecc9-11e8-8596-b5e947cb7a86.png)
(also added tool tip for truncated filter) 

**Note:** Did not remove the 'abort' button, it's just not available for this job.

Closes #519