### PR TITLE
improve the clarity of the the status buttons

### DIFF
--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -184,7 +184,7 @@ describe('JobListComponent', () => {
 
     // We don't finish loading until we complete a query that matches the
     // the ActiveRoute; so trigger a real navigate to clear the loading state.
-    de.query(By.css('.active-button')).nativeElement.click();
+    de.query(By.css('.running-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
     expect(de.queryAll(By.css('.spinner-container')).length).toEqual(0);
@@ -251,7 +251,7 @@ describe('JobListComponent', () => {
     fixture.detectChanges();
 
     let de: DebugElement = fixture.debugElement;
-    de.query(By.css('.completed-button')).nativeElement.click();
+    de.query(By.css('.succeeded-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
     tick();
@@ -265,7 +265,7 @@ describe('JobListComponent', () => {
 
     // Filter by active to filter out jobs after they've been aborted.
     let de: DebugElement = fixture.debugElement;
-    de.query(By.css('.active-button')).nativeElement.click();
+    de.query(By.css('.running-button')).nativeElement.click();
     fixture.detectChanges();
 
     // We select the first page (3 jobs) and abort. Jobs 3 and 4 are unaffected.

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -38,20 +38,9 @@
     <!-- Always include child divs, to support flex box style placement. -->
     <div>
       <ng-container *ngIf="shouldDisplayStatusButtons()">
-        <button mat-raised-button class="running-button status-button" (click)="showJobsWithStatus('Running')">
-          Running <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Running') }})</span>
-        </button>
-        <button mat-raised-button class="succeeded-button status-button" (click)="showJobsWithStatus('Succeeded')">
-          Succeeded <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Succeeded') }})</span>
-        </button>
-        <button mat-raised-button class="failed-button status-button" (click)="showJobsWithStatus('Failed')">
-          Failed <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Failed') }})</span>
-        </button>
-        <button mat-raised-button class="aborted-button status-button" (click)="showJobsWithStatus('Aborted')">
-          Aborted <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Aborted') }})</span>
-        </button>
-        <button mat-raised-button class="onhold-button status-button" (click)="showJobsWithStatus('OnHold')">
-          On Hold <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('OnHold') }})</span>
+        <button class="mat-raised-button status-button {{ status | lowercase }}-button" (click)="showJobsWithStatus(status)" *ngFor="let status of buttonStatuses">
+          <clr-icon [attr.shape]="getStatusIcon(status)" size="18"></clr-icon>
+          {{ status }} <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus(status) }})</span>
         </button>
       </ng-container>
    </div>

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -38,19 +38,19 @@
     <!-- Always include child divs, to support flex box style placement. -->
     <div>
       <ng-container *ngIf="shouldDisplayStatusButtons()">
-        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Running')">
+        <button mat-raised-button class="running-button status-button" (click)="showJobsWithStatus('Running')">
           Running <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Running') }})</span>
         </button>
-        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Succeeded')">
+        <button mat-raised-button class="succeeded-button status-button" (click)="showJobsWithStatus('Succeeded')">
           Succeeded <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Succeeded') }})</span>
         </button>
-        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Failed')">
+        <button mat-raised-button class="failed-button status-button" (click)="showJobsWithStatus('Failed')">
           Failed <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Failed') }})</span>
         </button>
-        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Aborted')">
+        <button mat-raised-button class="aborted-button status-button" (click)="showJobsWithStatus('Aborted')">
           Aborted <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Aborted') }})</span>
         </button>
-        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('OnHold')">
+        <button mat-raised-button class="onhold-button status-button" (click)="showJobsWithStatus('OnHold')">
           On Hold <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('OnHold') }})</span>
         </button>
       </ng-container>

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -38,17 +38,20 @@
     <!-- Always include child divs, to support flex box style placement. -->
     <div>
       <ng-container *ngIf="shouldDisplayStatusButtons()">
-        <button mat-raised-button class="status-button active-button" (click)="showActiveJobs()">
-          Active <span *ngIf="shouldDisplayStatusCounts()">({{ getActiveCount() }})</span>
+        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Running')">
+          Running <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Running') }})</span>
         </button>
-        <button mat-raised-button class="status-button failed-button" (click)="showFailedJobs()">
-          Failed <span *ngIf="shouldDisplayStatusCounts()">({{ getFailedCount() }})</span>
+        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Succeeded')">
+          Succeeded <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Succeeded') }})</span>
         </button>
-        <button mat-raised-button class="status-button completed-button" (click)="showCompletedJobs()">
-          Completed <span *ngIf="shouldDisplayStatusCounts()">({{ getCompletedCount() }})</span>
+        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Failed')">
+          Failed <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Failed') }})</span>
         </button>
-        <button mat-raised-button class="status-button onhold-button" (click)="showOnHoldJobs()">
-          On Hold <span *ngIf="shouldDisplayStatusCounts()">({{ getOnHoldCount() }})</span>
+        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('Aborted')">
+          Aborted <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('Aborted') }})</span>
+        </button>
+        <button mat-raised-button class="status-button" (click)="showJobsWithStatus('OnHold')">
+          On Hold <span *ngIf="shouldDisplayStatusCounts()">({{ getJobsCountForStatus('OnHold') }})</span>
         </button>
       </ng-container>
    </div>

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -133,7 +133,7 @@ describe('HeaderComponent', () => {
     fixture.detectChanges();
     fixture.whenStable().then(() => {
       fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(4);
+      expect(fixture.debugElement.queryAll(By.css('.status-button')).length).toEqual(5);
     });
   }));
 
@@ -150,7 +150,7 @@ describe('HeaderComponent', () => {
     fixture.whenStable().then(() => {
       fixture.detectChanges();
       expect(fixture.debugElement.query(
-        By.css('.active-button')).nativeElement.textContent).toContain('(2)');
+        By.css('.running-button')).nativeElement.textContent).toContain('(2)');
     });
   }));
 
@@ -167,7 +167,7 @@ describe('HeaderComponent', () => {
     fixture.whenStable().then(() => {
       fixture.detectChanges();
       expect(fixture.debugElement.query(
-        By.css('.active-button')).nativeElement.textContent).not.toContain('(2)');
+        By.css('.running-button')).nativeElement.textContent).not.toContain('(2)');
     });
   }));
 
@@ -215,7 +215,7 @@ describe('HeaderComponent', () => {
     tick();
     const de: DebugElement = fixture.debugElement;
     expect(de.queryAll(By.css('jm-filter-chip')).length).toEqual(2);
-    de.query(By.css('.completed-button')).nativeElement.click();
+    de.query(By.css('.succeeded-button')).nativeElement.click();
     tick();
     fixture.detectChanges();
     const lastFilter = de.queryAll(By.css('jm-filter-chip'))[2].componentInstance;

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -28,7 +28,7 @@ import {
 import {CapabilitiesService} from '../../core/capabilities.service';
 import {URLSearchParamsUtils} from '../utils/url-search-params.utils';
 import {JobStatus} from '../model/JobStatus';
-import {FieldDataType} from '../common';
+import {FieldDataType, JobStatusIcon} from '../common';
 import {JobListView} from '../job-stream';
 import {FilterChipComponent} from "./chips/filter-chip.component";
 
@@ -55,6 +55,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   inputValue: string = '';
 
   filteredOptions: Observable<string[]>;
+  readonly buttonStatuses = ['Running', 'Succeeded', 'Failed', 'Aborted', 'OnHold'];
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -210,6 +211,10 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   getJobsCountForStatus(status: string): number {
     return this.jobs.value.results.filter(
       j => j.status == JobStatus[status]).length;
+  }
+
+  getStatusIcon(status: JobStatus): string {
+    return JobStatusIcon[status];
   }
 
   private refreshChips(query: string): void {

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -31,7 +31,6 @@ import {JobStatus} from '../model/JobStatus';
 import {FieldDataType} from '../common';
 import {JobListView} from '../job-stream';
 import {FilterChipComponent} from "./chips/filter-chip.component";
-import {CapabilitiesResponse} from "../model/CapabilitiesResponse";
 
 @Component({
   selector: 'jm-header',
@@ -56,11 +55,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
   inputValue: string = '';
 
   filteredOptions: Observable<string[]>;
-
-  private readonly activeStatuses = [JobStatus.Submitted, JobStatus.Running, JobStatus.Aborting];
-  private readonly completedStatuses = [JobStatus.Succeeded];
-  private readonly failedStatuses = [JobStatus.Failed, JobStatus.Aborted];
-  private readonly onHoldStatuses = [JobStatus.OnHold];
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -209,40 +203,13 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
     return this.jobs.value.exhaustive;
   }
 
-  showActiveJobs(): void {
-    this.navigateWithStatus(this.activeStatuses.slice())
+  showJobsWithStatus(status: string): void {
+    this.navigateWithStatus([JobStatus[status]]);
   }
 
-  showCompletedJobs(): void {
-    this.navigateWithStatus(this.completedStatuses.slice())
-  }
-
-  showFailedJobs(): void {
-    this.navigateWithStatus(this.failedStatuses.slice());
-  }
-
-  showOnHoldJobs(): void {
-    this.navigateWithStatus(this.onHoldStatuses.slice());
-  }
-
-  getActiveCount(): number {
+  getJobsCountForStatus(status: string): number {
     return this.jobs.value.results.filter(
-      j => this.activeStatuses.includes(j.status)).length;
-  }
-
-  getFailedCount(): number {
-    return this.jobs.value.results.filter(
-      j => this.failedStatuses.includes(j.status)).length;
-  }
-
-  getCompletedCount(): number {
-    return this.jobs.value.results.filter(
-      j => this.completedStatuses.includes(j.status)).length;
-  }
-
-  getOnHoldCount(): number {
-    return this.jobs.value.results.filter(
-      j => this.onHoldStatuses.includes(j.status)).length;
+      j => j.status == JobStatus[status]).length;
   }
 
   private refreshChips(query: string): void {


### PR DESCRIPTION
After noting issues during user testing, change the quick filter status buttons to correspond to just one status.  After feedback from demo, add status icon.

Before:
![screen shot 2018-11-20 at 1 53 29 pm](https://user-images.githubusercontent.com/1713505/48795883-1daa8c80-eccc-11e8-9441-6e049d6cf1ce.png)

After:
![screen shot 2018-11-26 at 3 15 26 pm](https://user-images.githubusercontent.com/1713505/49039766-b048a100-f18e-11e8-8eb3-986bba0b5d52.png)

Closes #518 