### PR TITLE
Add button to clear the query builder chips

### DIFF
--- a/ui/src/app/shared/header/header.component.css
+++ b/ui/src/app/shared/header/header.component.css
@@ -123,3 +123,11 @@ clr-tooltip-content {
   display: block;
   margin: -0.6rem 0.5rem 0 0;
 }
+
+button.clear-query {
+  top: 0px;
+  left: -50px;
+  padding: 0px;
+  height: 40px;
+  width: 40px;
+}

--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -33,6 +33,9 @@
       </mat-autocomplete>
     </mat-chip-list>
   </mat-form-field>
+  <button mat-button *ngIf="hasChipsToClear()" matSuffix mat-icon-button aria-label="Clear" (click)="removeAllChips()" class="clear-query">
+    <clr-icon shape="close" size="18"></clr-icon>
+  </button>
 
   <div *ngIf="showControls" class="search-table-controls">
     <!-- Always include child divs, to support flex box style placement. -->

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -198,6 +198,18 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
     this.search();
   }
 
+  hasChipsToClear(): boolean {
+    return this.getChipKeys().filter(key => key != 'projectId').length > 0;
+  }
+
+  removeAllChips(): void {
+    this.chips.forEach((value: string, key: string) => {
+      if (key != 'projectId') {
+        this.chips.delete(key);
+      }
+    });
+  }
+
   // TODO: Cut the dependency on string parsing to represent lists here
   search(): void {
     let paramMap: Map<string, string[]> = new Map();

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -208,6 +208,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, AfterViewChecked,
         this.chips.delete(key);
       }
     });
+    this.search();
   }
 
   // TODO: Cut the dependency on string parsing to represent lists here


### PR DESCRIPTION
before:
<img width="984" alt="qb-before" src="https://user-images.githubusercontent.com/1713505/49820154-216a8580-fd45-11e8-8f5e-92ac2fbd808e.png">

after:
<img width="984" alt="screen shot 2018-12-11 at 12 21 55 pm" src="https://user-images.githubusercontent.com/1713505/49820008-c9cc1a00-fd44-11e8-8318-db765828bfd9.png">

Will not clear the `projectId` chip, as requested.

Closes #388 