### PR TITLE
Return more accurate scattered task status

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -403,7 +403,7 @@ def _get_scattered_task_status(metadata):
     }
     # return status by ranked applicability
     for status in [
-            'Failed', 'Aborted', 'Aborting', 'Running', 'Submitted',
+            'Failed', 'Aborting', 'Aborted', 'Running', 'Submitted',
             'Succeeded'
     ]:
         if status in statuses:

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -397,7 +397,10 @@ def _format_query_labels(orig_query_labels):
 
 def _get_scattered_task_status(metadata):
     # get all shard statuses
-    statuses = {shard.get('executionStatus') for shard in metadata}
+    statuses = {
+        task_statuses.cromwell_execution_to_api(shard.get('executionStatus'))
+        for shard in metadata
+    }
     # return status by ranked applicability
     for status in [
             'Failed', 'Aborted', 'Aborting', 'Running', 'Submitted',

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -208,7 +208,7 @@ def format_scattered_task(task_name, task_metadata):
     return TaskMetadata(
         name=remove_workflow_name(task_name),
         execution_status=task_statuses.cromwell_execution_to_api(
-            task_metadata[-1].get('executionStatus')),
+            _get_scattered_task_status(task_metadata)),
         start=minStart,
         end=maxEnd,
         attempts=task_metadata[-1].get('attempt'),
@@ -394,3 +394,15 @@ def _format_query_labels(orig_query_labels):
     for key, val in orig_query_labels.items():
         query_labels[urllib.unquote(key)] = urllib.unquote(val)
     return query_labels
+
+
+def _get_scattered_task_status(metadata):
+    status = metadata[0].get('executionStatus')
+    for shard in metadata:
+        if shard.get('executionStatus') in ['Failed', 'Aborting', 'Aborted']:
+            return shard.get('executionStatus')
+        elif shard.get('executionStatus') in ['Submitted', 'Running']:
+            return shard.get('executionStatus')
+        else:
+            status = shard.get('executionStatus')
+    return status


### PR DESCRIPTION
Take all returned shard statuses into account when figuring out the status of a scattered task.

Closes #542 