### PR TITLE
replaced calls to getResourceURL with getDirectoryBrowserURL

### DIFF
--- a/ui/src/app/job-details/common/failures-table/failures-table.component.ts
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.ts
@@ -24,7 +24,7 @@ export class JobFailuresTableComponent implements OnInit {
   }
 
   getResourceUrl(url: string): string {
-    return ResourceUtils.getResourceURL(url);
+    return ResourceUtils.getDirectoryBrowserURL(url);
   }
 
   getTaskDirectory(task: TaskMetadata): string {

--- a/ui/src/app/job-details/tabs/tabs.component.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.ts
@@ -63,7 +63,7 @@ export class JobTabsComponent implements OnInit, OnChanges {
   }
 
   getResourceUrl(url: string): string {
-    return ResourceUtils.getResourceURL(url);
+    return ResourceUtils.getDirectoryBrowserURL(url);
   }
 
   getTaskDirectory(task: TaskMetadata): string {


### PR DESCRIPTION
As of recently, `getResourceURL` links do not work with files that are behind authentication, so this replaces them with calls to `getDirectoryBrowserURL`.