### PR TITLE
Handle auth failure more elegantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Job Manager Change Log
 
+## v0.5.7 Release Notes
+
+### Added events to timing diagram
+
+Timing diagram now includes events within each task/subworkflow and the rendered width is no longer hard-coded.
+
+### Added better error handling to authentication
+
 ## v0.5.6 Release Notes
 
 ### Embedded timing diagram within UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Timing diagram now includes events within each task/subworkflow and the rendered
 
 ### Added better error handling to authentication
 
+Capture the error in cases where the UI is trying to use OAuth but the Cromwell it's pointing at doesn't require authentication.
+
 ## v0.5.6 Release Notes
 
 ### Embedded timing diagram within UI

--- a/ui/src/app/core/auth.service.ts
+++ b/ui/src/app/core/auth.service.ts
@@ -23,8 +23,9 @@ export class AuthService {
       gapi.auth2.init({
         client_id: clientId,
         cookiepolicy: 'single_host_origin',
-        scope: scopes.join(" ")
-      }).catch(error => reject(error));
+        scope: scopes.join(" "),
+      }).then(() => resolve())
+        .catch((error) => reject(error))
     });
   }
 

--- a/ui/src/app/core/auth.service.ts
+++ b/ui/src/app/core/auth.service.ts
@@ -3,6 +3,7 @@ import {Injectable, NgZone} from '@angular/core';
 
 import {CapabilitiesService} from './capabilities.service';
 import {ConfigLoaderService} from "../../environments/config-loader.service";
+import {MatSnackBar} from "@angular/material";
 
 declare const gapi: any;
 
@@ -17,6 +18,10 @@ export class AuthService {
 
   private initAuth(scopes: string[]): Promise<void> {
     const clientId = this.configLoader.getEnvironmentConfigSynchronous()['clientId'];
+
+    if (!clientId) {
+      this.snackBar.open('authorization is required by the capabilities config, but client ID is not set in the environment config');
+    }
     return gapi.auth2.init({
       client_id: clientId,
       cookiepolicy: 'single_host_origin',
@@ -39,7 +44,8 @@ export class AuthService {
   }
 
   constructor(private zone: NgZone, capabilitiesService: CapabilitiesService,
-              private configLoader: ConfigLoaderService) {
+              private configLoader: ConfigLoaderService,
+              private snackBar: MatSnackBar) {
     capabilitiesService.getCapabilities().then(capabilities => {
       if (!capabilities.authentication || !capabilities.authentication.isRequired) {
         return;

--- a/ui/src/app/core/auth.service.ts
+++ b/ui/src/app/core/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
     const clientId = this.configLoader.getEnvironmentConfigSynchronous()['clientId'];
 
     if (!clientId) {
-      this.snackBar.open('authorization is required by the capabilities config, but client ID is not set in the environment config');
+      this.snackBar.open('authorization is required by the capabilities config, but \'clientId\' is not available');
     }
     return gapi.auth2.init({
       client_id: clientId,

--- a/ui/src/app/dashboard/dashboard.component.spec.ts
+++ b/ui/src/app/dashboard/dashboard.component.spec.ts
@@ -6,6 +6,7 @@ import {
   MatButtonModule,
   MatCardModule,
   MatSelectModule,
+  MatSnackBar,
   MatSortModule,
   MatTableModule
 } from '@angular/material';
@@ -129,7 +130,7 @@ describe('DashboardComponent', () => {
   let fakeCapabilitiesService: FakeCapabilitiesService;
   let settingsService: SettingsService;
   let authService: AuthService;
-
+  let snackBar: MatSnackBar;
   const TEST_PROJECT = 'test-project';
 
   beforeEach(async(() => {
@@ -142,7 +143,7 @@ describe('DashboardComponent', () => {
       ]
     };
     fakeCapabilitiesService = new FakeCapabilitiesService(capabilities);
-    authService = new AuthService(null, fakeCapabilitiesService, null);
+    authService = new AuthService(null, fakeCapabilitiesService, null, snackBar);
     settingsService = new SettingsService(authService, fakeCapabilitiesService, localStorage);
     TestBed.configureTestingModule({
       declarations: [

--- a/ui/src/app/job-details/tabs/tabs.component.spec.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.spec.ts
@@ -5,7 +5,7 @@ import {Component, DebugElement, ViewChild} from '@angular/core';
 import {
   MatButtonModule,
   MatExpansionModule,
-  MatMenuModule,
+  MatMenuModule, MatSnackBar,
   MatTableModule,
   MatTabsModule,
   MatTooltipModule,
@@ -51,6 +51,7 @@ describe('JobTabsComponent', () => {
     submission: new Date('2015-04-20T20:00:00'),
     extensions: { tasks: [task] }
   }
+  let snackBar: MatSnackBar;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -76,7 +77,7 @@ describe('JobTabsComponent', () => {
         SharedModule
       ],
       providers: [
-        {provide: AuthService, useValue: new AuthService(null, new FakeCapabilitiesService({}), null)}
+        {provide: AuthService, useValue: new AuthService(null, new FakeCapabilitiesService({}), null, snackBar)}
       ]
     }).compileComponents();
   }));

--- a/ui/src/app/job-list/job-list.component.spec.ts
+++ b/ui/src/app/job-list/job-list.component.spec.ts
@@ -12,7 +12,7 @@ import {
   MatMenuModule,
   MatPaginatorModule,
   MatSelectModule,
-  MatSlideToggleModule,
+  MatSlideToggleModule, MatSnackBar,
   MatSnackBarModule,
   MatSortModule,
   MatTableModule,
@@ -68,6 +68,7 @@ describe('JobListComponent', () => {
   let fakeCapabilitiesService: FakeCapabilitiesService;
   let settingsService: SettingsService;
   let authService: AuthService;
+  let snackBar: MatSnackBar;
 
   beforeEach(async(() => {
     fakeJobService = new FakeJobManagerService(testJobs(5));
@@ -80,7 +81,7 @@ describe('JobListComponent', () => {
       ]
     };
     fakeCapabilitiesService = new FakeCapabilitiesService(capabilities);
-    authService = new AuthService(null, fakeCapabilitiesService, null);
+    authService = new AuthService(null, fakeCapabilitiesService, null, snackBar);
     settingsService = new SettingsService(authService, fakeCapabilitiesService, localStorage);
     TestBed.configureTestingModule({
       declarations: [

--- a/ui/src/app/shared/header/header.component.spec.ts
+++ b/ui/src/app/shared/header/header.component.spec.ts
@@ -12,7 +12,7 @@ import {
   MatListModule,
   MatMenuModule,
   MatNativeDateModule,
-  MatPaginatorModule, MatSlideToggleModule,
+  MatPaginatorModule, MatSlideToggleModule, MatSnackBar,
 } from "@angular/material";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {RouterTestingModule} from "@angular/router/testing";
@@ -49,6 +49,7 @@ describe('HeaderComponent', () => {
 
   let testComponent: HeaderComponent;
   let fixture: ComponentFixture<TestHeaderComponent>;
+  let snackBar: MatSnackBar;
   let capabilities: CapabilitiesResponse = {
     displayFields: [
       {field: 'status', display: 'Status'},
@@ -61,7 +62,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(async(() => {
     const fakeCapabilitiesService = new FakeCapabilitiesService(capabilities);
-    const authService = new AuthService(null, fakeCapabilitiesService, null);
+    const authService = new AuthService(null, fakeCapabilitiesService, null, snackBar);
 
     TestBed.configureTestingModule({
       declarations: [HeaderComponent, TestHeaderComponent, MockFilterChipComponent],


### PR DESCRIPTION
Now, when user has an `authorization` section in their capabilities config (or something else that causes `gapi.auth2` to fail, the error is caught and displayed to the user:

<img width="1134" alt="screen shot 2019-02-21 at 10 29 16 am" src="https://user-images.githubusercontent.com/1713505/53180558-c4e8d980-35c3-11e9-9ae5-30d07680052b.png">

instead of just failing and dumping the error message in the javascript console.

Closes #441 