### PR TITLE
adjusted styles for cards on job details page

### DIFF
--- a/ui/src/app/job-details/common/failures-table/failures-table.component.css
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.css
@@ -80,6 +80,7 @@ td.failure-links {
 :host-context(mat-card.card) td,
 :host-context(mat-card.card) th {
   padding: 5px 10px 5px 0px;
+  line-height: 0.7rem;
 }
 
 :host-context(mat-card.card) .mat-row:last-child td {
@@ -89,6 +90,7 @@ td.failure-links {
 :host-context(mat-card.card) .failure-task {
   width: 174px;
   max-width: 174px;
+  font-size: 0.7rem;
 }
 
 :host-context(mat-card.card) td.failure-links {

--- a/ui/src/app/job-details/panels/panels.component.css
+++ b/ui/src/app/job-details/panels/panels.component.css
@@ -32,7 +32,7 @@ p {
 .card {
   float: left;
   width: 18rem;
-  height: 10rem;
+  height: 11rem;
   margin: 1rem 1rem 3rem 1rem;
   border-radius: 5px;
   box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 3px 2px 0 rgba(0,0,0,0.12);
@@ -52,7 +52,7 @@ p {
 }
 
 .card .mat-card-content {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   line-height: 1rem;
 }
 


### PR DESCRIPTION
Before:
<img width="703" alt="Screen Shot 2019-03-14 at 5 44 39 PM" src="https://user-images.githubusercontent.com/14366016/54393619-00d20480-4681-11e9-9b4e-30aaeb9ab272.png">

After:
![Screen Shot 2019-03-14 at 6 54 45 PM](https://user-images.githubusercontent.com/1713505/54396812-ad64b400-468a-11e9-8f89-0f329685046e.png)


Closes #591