### PR TITLE
Add in more human-friendly way to narrow down by date to query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v0.6.3 Release Notes
+
+### Added drop down menu to query builder for more intuitive filtering by date.
+
 ## v0.6.2 Release Notes
 
 ### Fixed bug where scattered tasks' status, duration, timing diagram and number of attempts were inaccurate.

--- a/ui/src/app/shared/filter-header/filter-header.component.css
+++ b/ui/src/app/shared/filter-header/filter-header.component.css
@@ -193,3 +193,20 @@ clr-tooltip-content {
   font-family: 'Montserrat', sans-serif;
   line-height: 1rem;
 }
+
+mat-form-field.submitted-select {
+  margin-left: 15px;
+  font-size: 0.75rem;
+}
+
+::ng-deep mat-form-field.submitted-select .mat-input-underline.mat-form-field-underline {
+  display: block;
+}
+
+::ng-deep mat-form-field.mat-form-field-type-mat-select.submitted-select .mat-form-field-infix.mat-input-infix {
+  padding: 5px;
+}
+
+::ng-deep mat-form-field.submitted-select .mat-select-arrow-wrapper .mat-select-arrow {
+  color: rgba(0, 0, 0, 0.54);
+}

--- a/ui/src/app/shared/filter-header/filter-header.component.html
+++ b/ui/src/app/shared/filter-header/filter-header.component.html
@@ -37,7 +37,7 @@
     <clr-icon shape="close" size="24" style="color: #5C912E"></clr-icon>
   </button>
   <mat-form-field class="submitted-select" *ngIf="showTimeFrame">
-    <mat-label>Submitted: all</mat-label>
+    <mat-label>Submitted: all time</mat-label>
     <mat-select (selectionChange)="onTimeFrameChange($event.value)">
       <mat-option *ngFor="let timeFrame of timeFrames" [value]="timeFrame">
         {{timeFrame}}

--- a/ui/src/app/shared/filter-header/filter-header.component.html
+++ b/ui/src/app/shared/filter-header/filter-header.component.html
@@ -36,6 +36,14 @@
   <button mat-button *ngIf="hasChipsToClear()" matSuffix mat-icon-button aria-label="Clear" (click)="removeAllChips()" class="clear-query">
     <clr-icon shape="close" size="24" style="color: #5C912E"></clr-icon>
   </button>
+  <mat-form-field class="submitted-select" *ngIf="showTimeFrame">
+    <mat-label>Submitted: all</mat-label>
+    <mat-select (selectionChange)="onTimeFrameChange($event.value)">
+      <mat-option *ngFor="let timeFrame of timeFrames" [value]="timeFrame">
+        {{timeFrame}}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
 
   <div *ngIf="showControls" class="search-table-controls">
     <!-- Always include child divs, to support flex box style placement. -->

--- a/ui/src/app/shared/filter-header/filter-header.component.spec.ts
+++ b/ui/src/app/shared/filter-header/filter-header.component.spec.ts
@@ -12,7 +12,10 @@ import {
   MatListModule,
   MatMenuModule,
   MatNativeDateModule,
-  MatPaginatorModule, MatSlideToggleModule, MatSnackBar,
+  MatPaginatorModule,
+  MatSelectModule,
+  MatSlideToggleModule,
+  MatSnackBar,
 } from "@angular/material";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {RouterTestingModule} from "@angular/router/testing";
@@ -82,6 +85,7 @@ describe('FilterHeaderComponent', () => {
         MatMenuModule,
         MatNativeDateModule,
         MatPaginatorModule,
+        MatSelectModule,
         MatSlideToggleModule,
         ReactiveFormsModule,
         RouterTestingModule.withRoutes([

--- a/ui/src/app/shared/filter-header/filter-header.component.ts
+++ b/ui/src/app/shared/filter-header/filter-header.component.ts
@@ -123,7 +123,7 @@ export class FilterHeaderComponent implements OnInit, AfterViewInit, AfterViewCh
       });
       this.chipToExpand = null;
     }
-    this.showTimeFrame = !(this.chips.has('start') || this.chips.has('end') || this.chips.has('submission'));
+    this.showTimeFrame = !(this.chips.has('start') || this.chips.has('end') || this.chips.has('submission')) && this.showControls;
     this.cdr.detectChanges();
   }
 

--- a/ui/src/app/shared/filter-header/filter-header.component.ts
+++ b/ui/src/app/shared/filter-header/filter-header.component.ts
@@ -68,6 +68,9 @@ export class FilterHeaderComponent implements OnInit, AfterViewInit, AfterViewCh
   private readonly capabilities: CapabilitiesResponse;
   projectId: string;
 
+  showTimeFrame = true;
+  timeFrames  = ['', 'Today', 'Last 3 days', 'Last 7 days', 'This month'];
+
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
@@ -120,6 +123,7 @@ export class FilterHeaderComponent implements OnInit, AfterViewInit, AfterViewCh
       });
       this.chipToExpand = null;
     }
+    this.showTimeFrame = !(this.chips.has('start') || this.chips.has('end') || this.chips.has('submission'));
     this.cdr.detectChanges();
   }
 
@@ -272,6 +276,32 @@ export class FilterHeaderComponent implements OnInit, AfterViewInit, AfterViewCh
 
   saveSettings() {
     this.onDisplayFieldsChanged.emit(this.displayFields);
+  }
+
+  onTimeFrameChange(newTimeFrame: string) {
+    let newSubmission:string;
+    let d = new Date();
+    switch(newTimeFrame) {
+      case 'Today':
+        newSubmission = ((d.getMonth()) + 1 % 12).toString() + '/' + d.getDate() + '/' + d.getFullYear();
+        break;
+      case 'Last 3 days':
+        console.log(d);
+        d.setDate(d.getDate() - 3);
+        console.log(d);
+        newSubmission = ((d.getMonth()) + 1 % 12).toString() + '/' + d.getDate() + '/' + d.getFullYear();
+        break;
+      case 'Last 7 days':
+        d.setDate(d.getDate() - 7);
+        newSubmission = ((d.getMonth()) + 1 % 12).toString() + '/' + d.getDate() + '/' + d.getFullYear();
+        break;
+      case 'This month':
+        newSubmission = ((d.getMonth()) + 1 % 12).toString() + '/1/' + d.getFullYear();
+        break;
+    }
+    if (newSubmission) {
+      this.addChip('submission:' + newSubmission);
+    }
   }
 
   private refreshChips(query: string): void {

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -19,6 +19,7 @@ import {
   MatNativeDateModule,
   MatPaginatorModule,
   MatRadioModule,
+  MatSelectModule,
   MatSlideToggleModule
 } from "@angular/material";
 import {ClrIconModule, ClrTooltipModule} from '@clr/angular';
@@ -48,9 +49,10 @@ import {DatetimeComponent} from "./datetime/datetime.component";
     MatMenuModule,
     MatNativeDateModule,
     MatPaginatorModule,
-    ReactiveFormsModule,
     MatRadioModule,
-    MatSlideToggleModule
+    MatSelectModule,
+    MatSlideToggleModule,
+    ReactiveFormsModule,
   ],
   declarations: [
     DatepickerInputComponent,


### PR DESCRIPTION
The dropdown:
![Screen Shot 2019-03-18 at 6 24 40 PM](https://user-images.githubusercontent.com/1713505/54568911-6d197480-49af-11e9-86b8-a0eaaef17605.png)

The options:
![Screen Shot 2019-03-18 at 6 24 54 PM](https://user-images.githubusercontent.com/1713505/54568919-6f7bce80-49af-11e9-9850-80bb40a5e015.png)

After the user selects an option:
![Screen Shot 2019-03-18 at 6 56 19 PM](https://user-images.githubusercontent.com/1713505/54568965-96d29b80-49af-11e9-9c59-7ba71c21d9dc.png)


Closes #440 