### PR TITLE
More useful UI behavior when user submits bad jobs query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed bug where failure message(s) are not displayed if the job failed before Cromwell was able to run it (most likely due to a validation error).
 
+### Remove 'loading' screen when user has made an invalid query on job list page so the user can make changes.
+
 ## v0.6.2 Release Notes
 
 ### Fixed bug where scattered tasks' status, duration, timing diagram and number of attempts were inaccurate.

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -150,6 +150,12 @@ export class JobListComponent implements OnInit {
   }
 
   handleError(error: any) {
+    // if the request went bad, remove the last chip that was added
+    if (error.hasOwnProperty('title') && error.title == 'Bad Request') {
+      let lastChipKey = this.header.getChipKeys().pop();
+      this.header.removeChip(lastChipKey);
+    }
+
     this.snackBar.open(
       new ErrorMessageFormatterPipe().transform(error),
       'Dismiss',

--- a/ui/src/app/job-list/job-list.component.ts
+++ b/ui/src/app/job-list/job-list.component.ts
@@ -150,11 +150,7 @@ export class JobListComponent implements OnInit {
   }
 
   handleError(error: any) {
-    // if the request went bad, remove the last chip that was added
-    if (error.hasOwnProperty('title') && error.title == 'Bad Request') {
-      let lastChipKey = this.header.getChipKeys().pop();
-      this.header.removeChip(lastChipKey);
-    }
+    this.setLoading(false, false);
 
     this.snackBar.open(
       new ErrorMessageFormatterPipe().transform(error),


### PR DESCRIPTION
Remove 'loading' screen when user has made an invalid query on job list page so the user can make changes.

Closes #569