### PR TITLE
Move all output icons into one component and re-use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed bug where failure message(s) are not displayed if the job failed before Cromwell was able to run it (most likely due to a validation error).
 
+### Made behavior of message, log and execution icons consistent across all contexts in the job details page.
+
 ## v0.6.2 Release Notes
 
 ### Fixed bug where scattered tasks' status, duration, timing diagram and number of attempts were inaccurate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Made behavior of message, log and execution icons consistent across all contexts in the job details page.
 
+Also fixed bug where log file links were being treated like directories.
+
 ## v0.6.2 Release Notes
 
 ### Fixed bug where scattered tasks' status, duration, timing diagram and number of attempts were inaccurate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Made behavior of message, log and execution icons consistent across all contexts in the job details page.
 
-Also fixed bug where log file links were being treated like directories.
+Also fixed bug where Google Console file links sometimes pointed to unexpected places.
 
 ## v0.6.2 Release Notes
 

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.css
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.css
@@ -1,0 +1,14 @@
+clr-tooltip-content {
+  background-color: rgba(0, 0, 0, 0.65);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.65rem;
+  color: #fff;
+  display: block;
+  margin: -0.6rem 0.5rem 0 0;
+  height: auto;
+  line-height: 1rem;
+}
+
+clr-tooltip a {
+  text-decoration: none;
+}

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -2,7 +2,7 @@
   <clr-tooltip *ngIf="displayMessage">
     <a class="log-item">
       <clr-icon clrTooltipTrigger shape="exclamation-triangle" size="24" style="color:#5C912E"></clr-icon>
-      <clr-tooltip-content clrPosition="bottom-right" clrSize="xs" class="message" *clrIfOpen>
+      <clr-tooltip-content clrPosition="bottom-left" clrSize="xs" class="message" *clrIfOpen>
         <span>{{ message }}</span>
       </clr-tooltip-content>
     </a>

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -1,0 +1,37 @@
+<div class="debug-icons">
+  <clr-tooltip *ngIf="displayMessage">
+    <a class="log-item">
+      <clr-icon clrTooltipTrigger shape="exclamation-triangle" size="24" style="color:#5C912E"></clr-icon>
+      <clr-tooltip-content clrPosition="bottom-right" clrSize="xs" class="message" *clrIfOpen>
+        <span>{{ message }}</span>
+      </clr-tooltip-content>
+    </a>
+  </clr-tooltip>
+ <clr-icon *ngIf="!getResourceUrl(stdout)" shape="file" size="24" style="color: #ccc;"></clr-icon>
+  <clr-tooltip *ngIf="getResourceUrl(stdout)">
+    <a class="log-item" [href]="getResourceUrl(stdout)" target="_blank">
+      <clr-icon clrTooltipTrigger shape="file" size="24" style="color: #5C912E;"></clr-icon>
+      <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
+        <span>stderr log</span>
+      </clr-tooltip-content>
+    </a>
+  </clr-tooltip>
+  <clr-icon *ngIf="!getResourceUrl(stderr)" shape="file" size="24" style="color: #ccc;"></clr-icon>
+  <clr-tooltip *ngIf="getResourceUrl(stderr)">
+    <a class="log-item" [href]="getResourceUrl(stderr)" target="_blank">
+      <clr-icon clrTooltipTrigger shape="file" size="24" class="has-alert log-error" style="color: #5C912E;"></clr-icon>
+      <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
+        <span>stderr log</span>
+      </clr-tooltip-content>
+    </a>
+  </clr-tooltip>
+  <clr-icon *ngIf="!getTaskDirectory(directory)" shape="file" size="24" class="has-alert log-error" style="color: #ccc;"></clr-icon>
+  <clr-tooltip *ngIf="getTaskDirectory(directory)">
+    <a class="log-item" [href]="getTaskDirectory(directory)" target="_blank">
+      <clr-icon clrTooltipTrigger shape="folder" size="24" class="is-solid" style="color:#5C912E"></clr-icon>
+      <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
+        <span>execution directory</span>
+      </clr-tooltip-content>
+    </a>
+  </clr-tooltip>
+</div>

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -16,7 +16,7 @@
       </clr-tooltip-content>
     </a>
   </clr-tooltip>
-  <clr-icon *ngIf="!getResourceUrl(stderr)" shape="file" size="24" style="color: #ccc;"></clr-icon>
+  <clr-icon *ngIf="!getResourceUrl(stderr)" shape="file" class="has-alert log-error disabled" size="24" style="color: #ccc;"></clr-icon>
   <clr-tooltip *ngIf="getResourceUrl(stderr)">
     <a class="log-item" [href]="getResourceUrl(stderr)" target="_blank">
       <clr-icon clrTooltipTrigger shape="file" size="24" class="has-alert log-error" style="color: #5C912E;"></clr-icon>
@@ -25,7 +25,7 @@
       </clr-tooltip-content>
     </a>
   </clr-tooltip>
-  <clr-icon *ngIf="!getTaskDirectory(directory)" shape="file" size="24" class="has-alert log-error" style="color: #ccc;"></clr-icon>
+  <clr-icon *ngIf="!getTaskDirectory(directory)" shape="folder" size="24" class="is-solid" style="color: #ccc;"></clr-icon>
   <clr-tooltip *ngIf="getTaskDirectory(directory)">
     <a class="log-item" [href]="getTaskDirectory(directory)" target="_blank">
       <clr-icon clrTooltipTrigger shape="folder" size="24" class="is-solid" style="color:#5C912E"></clr-icon>

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
@@ -1,0 +1,92 @@
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {Component, DebugElement, ViewChild} from '@angular/core';
+import {ClrIconModule, ClrTooltipModule} from '@clr/angular';
+import {SharedModule} from '../../../shared/shared.module';
+import {JobDebugIconsComponent} from "./debug-icons.component";
+import {JobMetadataResponse} from "../../../shared/model/JobMetadataResponse";
+import {AuthService} from "../../../core/auth.service";
+import {FakeCapabilitiesService} from "../../../testing/fake-capabilities.service";
+import {MatSnackBar} from "@angular/material";
+
+describe('JobDebugIconsComponent', () => {
+  let fixture: ComponentFixture<TestDebugIconsComponent>;
+  let snackBar: MatSnackBar;
+  let testComponent: JobDebugIconsComponent;
+  let job: JobMetadataResponse = {
+    failure: 'things went wrong',
+    stdout : 'gs://test-bucket/test-job/stdout.txt',
+    stderr: 'gs://test-bucket/test-job/stderr.txt',
+    callRoot: 'gs://test-bucket/test-job'
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TestDebugIconsComponent,
+        JobDebugIconsComponent
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        ClrIconModule,
+        ClrTooltipModule,
+        SharedModule
+      ],
+      providers: [
+        {provide: AuthService, useValue: new AuthService(null, new FakeCapabilitiesService({}), null, snackBar)}
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestDebugIconsComponent);
+    testComponent = fixture.componentInstance;
+  });
+
+  it('should not display message icon if displayMessage is set to false', async(() => {
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    expect(de.queryAll(By.css('clr-icon[shape=exclamation-triangle]')).length).toEqual(0);
+  }));
+
+  it('should display message icon if displayMessage is set to true', async(() => {
+    fixture.detectChanges();
+    testComponent.displayMessage = true;
+    let de: DebugElement = fixture.debugElement;
+    fixture.detectChanges();
+    expect(de.queryAll(By.css('clr-icon[shape=exclamation-triangle]')).length).toEqual(1);
+  }));
+
+  it('should link to the right location for stdout', async(() => {
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    expect(de.queryAll(By.css('a.log-item'))[0].nativeElement.href).toEqual('https://console.cloud.google.com/storage/browser/test-bucket/test-job?prefix=stdout.txt');
+  }));
+
+  it('should link to the right location for stderr', async(() => {
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    expect(de.queryAll(By.css('a.log-item'))[1].nativeElement.href).toEqual('https://console.cloud.google.com/storage/browser/test-bucket/test-job?prefix=stderr.txt');
+  }));
+
+  it('should link to the right location for execution directory', async(() => {
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    expect(de.queryAll(By.css('a.log-item'))[2].nativeElement.href).toEqual('https://console.cloud.google.com/storage/browser/test-bucket/test-job/');
+  }));
+
+  @Component({
+    selector: 'jm-test-debug-icons-component',
+    template: `<jm-debug-icons [displayMessage]="displayMessage"
+                               [message]="job.failure"
+                               [stdout]="job.stdout"
+                               [stderr]="job.stderr"
+                               [directory]="job.callRoot"></jm-debug-icons>`
+  })
+  class TestDebugIconsComponent {
+    public job = job;
+    @ViewChild(JobDebugIconsComponent)
+    public jobDebugIconsComponent: JobDebugIconsComponent;
+  }
+});

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
@@ -13,8 +13,8 @@ import {MatSnackBar} from "@angular/material";
 describe('JobDebugIconsComponent', () => {
   let fixture: ComponentFixture<TestDebugIconsComponent>;
   let snackBar: MatSnackBar;
-  let testComponent: JobDebugIconsComponent;
-  let job: JobMetadataResponse = {
+  let testComponent: TestDebugIconsComponent;
+  let job = {
     failure: 'things went wrong',
     stdout : 'gs://test-bucket/test-job/stdout.txt',
     stderr: 'gs://test-bucket/test-job/stderr.txt',
@@ -52,7 +52,7 @@ describe('JobDebugIconsComponent', () => {
 
   it('should display message icon if displayMessage is set to true', async(() => {
     fixture.detectChanges();
-    testComponent.displayMessage = true;
+    testComponent.jobDebugIconsComponent.displayMessage = true;
     let de: DebugElement = fixture.debugElement;
     fixture.detectChanges();
     expect(de.queryAll(By.css('clr-icon[shape=exclamation-triangle]')).length).toEqual(1);

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
@@ -28,7 +28,7 @@ export class JobDebugIconsComponent implements OnInit {
     if (!url) {
       return '';
     }
-    return this.sanitizer.bypassSecurityTrustResourceUrl(ResourceUtils.getDirectoryBrowserURL(url, this.authService.userEmail));
+    return this.sanitizer.bypassSecurityTrustResourceUrl(ResourceUtils.getResourceBrowserURL(url, this.authService.userEmail));
   }
 
   getTaskDirectory(directory): SafeUrl {

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
@@ -1,0 +1,39 @@
+import {Component, Input, OnInit} from '@angular/core';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+
+import {AuthService} from '../../../core/auth.service';
+import {ResourceUtils} from "../../../shared/utils/resource-utils";
+
+@Component({
+  selector: 'jm-debug-icons',
+  templateUrl: './debug-icons.component.html',
+  styleUrls: ['./debug-icons.component.css']
+})
+export class JobDebugIconsComponent implements OnInit {
+  @Input() displayMessage: boolean;
+  @Input() message: string;
+  @Input() stdout: string;
+  @Input() stderr: string;
+  @Input() directory: string;
+
+  constructor(private authService: AuthService,
+              private sanitizer:DomSanitizer) {
+  }
+
+  ngOnInit() {
+    // mark URLs as safe
+  }
+
+  getResourceUrl(url: string): SafeUrl {
+    if (!url) {
+      return '';
+    }
+    return this.sanitizer.bypassSecurityTrustResourceUrl(ResourceUtils.getDirectoryBrowserURL(url, this.authService.userEmail));
+  }
+
+  getTaskDirectory(directory): SafeUrl {
+    if (directory) {
+      return this.sanitizer.bypassSecurityTrustResourceUrl(ResourceUtils.getDirectoryBrowserURL(directory, this.authService.userEmail));
+    }
+  }
+}

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.html
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.html
@@ -16,41 +16,12 @@
   <ng-container matColumnDef="links">
     <th mat-header-cell *matHeaderCellDef class="failure-links"> Log Files </th>
     <td mat-cell *matCellDef="let f" class="failure-links">
-      <clr-tooltip *ngIf="!displayedColumns.includes('message')">
-        <a class="log-item">
-          <clr-icon clrTooltipTrigger shape="exclamation-triangle" size="24" style="color:#5C912E"></clr-icon>
-          <clr-tooltip-content clrPosition="bottom-right" clrSize="xs" class="message" *clrIfOpen>
-            <span>{{ f.failure }}</span>
-          </clr-tooltip-content>
-        </a>
-      </clr-tooltip>
-      <clr-tooltip *ngIf="getResourceUrl(f.stdout)">
-        <a class="log-item" href="{{ getResourceUrl(f.stdout) }}">
-          <clr-icon clrTooltipTrigger shape="file" size="24" style="color:#5C912E"></clr-icon>
-          <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-            <span>stdout log</span>
-          </clr-tooltip-content>
-        </a>
-      </clr-tooltip>
-      <clr-icon *ngIf="!getResourceUrl(f.stdout)" shape="file" size="24" style="color: #ccc;"></clr-icon>
-      <clr-tooltip *ngIf="getResourceUrl(f.stderr)">
-        <a class="log-item" href="{{ getResourceUrl(f.stderr) }}">
-          <clr-icon clrTooltipTrigger shape="file" size="24" class="has-alert log-error" style="color: #5C912E;"></clr-icon>
-          <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-            <span>stderr log</span>
-          </clr-tooltip-content>
-        </a>
-      </clr-tooltip>
-      <clr-icon *ngIf="!getResourceUrl(f.stderr)" shape="file" size="24" class="has-alert log-error" style="color: #ccc;"></clr-icon>
-      <clr-tooltip *ngIf="getTaskDirectory(f)">
-        <a class="log-item" href="{{ getTaskDirectory(f) }}">
-          <clr-icon clrTooltipTrigger shape="folder" size="24" class="is-solid" style="color:#5C912E"></clr-icon>
-          <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-            <span>execution directory</span>
-          </clr-tooltip-content>
-        </a>
-      </clr-tooltip>
-      <clr-icon *ngIf="!getTaskDirectory(f)" shape="folder" size="24" class="is-solid" style="color: #ccc;"></clr-icon>
+      <jm-debug-icons [displayMessage]="!displayedColumns.includes('message')"
+                      [message]="f.failure"
+                      [stdout]="f.stdout"
+                      [stderr]="f.stderr"
+                      [directory]="getTaskDirectory(f)">
+      </jm-debug-icons>
     </td>
   </ng-container>
   <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.html
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.html
@@ -20,7 +20,7 @@
                       [message]="f.failure"
                       [stdout]="f.stdout"
                       [stderr]="f.stderr"
-                      [directory]="getTaskDirectory(f)">
+                      [directory]="f.callRoot">
       </jm-debug-icons>
     </td>
   </ng-container>

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.ts
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.ts
@@ -37,15 +37,4 @@ export class JobFailuresTableComponent implements OnInit {
       return ResourceUtils.getDirectoryBrowserURL(task.callRoot, this.authService.userEmail);
     }
   }
-
-  hasTaskNames(): boolean {
-    let status = false;
-    this.dataSource.forEach((failure) => {
-      if (failure.taskName) {
-        status = true;
-        return;
-      }
-    });
-    return status;
-  }
 }

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.ts
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.ts
@@ -1,9 +1,6 @@
 import {Component, Input, OnInit} from '@angular/core';
 
-import {AuthService} from '../../../core/auth.service';
 import {FailureMessage} from "../../../shared/model/FailureMessage";
-import {ResourceUtils} from "../../../shared/utils/resource-utils";
-import {TaskMetadata} from "../../../shared/model/TaskMetadata";
 
 @Component({
   selector: 'jm-failures-table',
@@ -19,22 +16,7 @@ export class JobFailuresTableComponent implements OnInit {
 
   dataSource: FailureMessage[];
 
-  constructor(private authService: AuthService) {}
-
   ngOnInit() {
     this.dataSource = this.failures.slice(0, this.numToShow);
-  }
-
-  getResourceUrl(url: string): string {
-    if (!url) {
-      return '';
-    }
-    return ResourceUtils.getDirectoryBrowserURL(url, this.authService.userEmail);
-  }
-
-  getTaskDirectory(task: TaskMetadata): string {
-    if (task.callRoot) {
-      return ResourceUtils.getDirectoryBrowserURL(task.callRoot, this.authService.userEmail);
-    }
   }
 }

--- a/ui/src/app/job-details/job-details.component.spec.ts
+++ b/ui/src/app/job-details/job-details.component.spec.ts
@@ -18,6 +18,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {ClrIconModule, ClrTooltipModule} from '@clr/angular';
 import {Ng2GoogleChartsModule} from 'ng2-google-charts';
 
+import {JobDebugIconsComponent} from "./common/debug-icons/debug-icons.component";
 import {JobDetailsComponent} from "./job-details.component"
 import {JobPanelsComponent} from './panels/panels.component';
 import {JobResourcesComponent} from './resources/resources.component';
@@ -59,6 +60,7 @@ describe('JobDetailsComponent', () => {
         AppComponent,
         FakeJobListComponent,
         TestJobDetailsComponent,
+        JobDebugIconsComponent,
         JobDetailsComponent,
         JobFailuresTableComponent,
         JobPanelsComponent,

--- a/ui/src/app/job-details/job-details.module.ts
+++ b/ui/src/app/job-details/job-details.module.ts
@@ -23,6 +23,7 @@ import {JobTabsComponent} from "./tabs/tabs.component";
 import {GcsService} from '../core/gcs.service';
 import {JobFailuresTableComponent} from './common/failures-table/failures-table.component';
 import {JobTimingDiagramComponent} from "./tabs/timing-diagram/timing-diagram.component";
+import {JobDebugIconsComponent} from "./common/debug-icons/debug-icons.component";
 import {Ng2GoogleChartsModule} from 'ng2-google-charts';
 
 
@@ -46,6 +47,7 @@ import {Ng2GoogleChartsModule} from 'ng2-google-charts';
     Ng2GoogleChartsModule
   ],
   declarations: [
+    JobDebugIconsComponent,
     JobDetailsComponent,
     JobPanelsComponent,
     JobResourcesComponent,

--- a/ui/src/app/job-details/panels/panels.component.spec.ts
+++ b/ui/src/app/job-details/panels/panels.component.spec.ts
@@ -16,6 +16,7 @@ import {JobStatus} from '../../shared/model/JobStatus';
 import {JobMetadataResponse} from '../../shared/model/JobMetadataResponse';
 import {JobPanelsComponent} from './panels.component';
 import {JobFailuresTableComponent} from "../common/failures-table/failures-table.component";
+import {JobDebugIconsComponent} from "../common/debug-icons/debug-icons.component";
 
 describe('JobPanelsComponent', () => {
 
@@ -46,6 +47,7 @@ describe('JobPanelsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        JobDebugIconsComponent,
         JobFailuresTableComponent,
         JobPanelsComponent,
         TestPanelsComponent

--- a/ui/src/app/job-details/resources/resources-table/resources-table.component.html
+++ b/ui/src/app/job-details/resources/resources-table/resources-table.component.html
@@ -5,7 +5,7 @@
   </ng-container>
   <ng-container matColumnDef="value">
     <td mat-cell *matCellDef="let key">
-      <a *ngIf="isResourceURL(key)" href="{{ getResourceURL(key) }}">{{ entries[key] }}</a>
+      <a *ngIf="isResourceURL(key)" href="{{ getResourceURL(key) }}" target="_blank">{{ entries[key] }}</a>
       <span *ngIf="!isResourceURL(key)">{{ entries[key] | json }}</span>
     </td>
   </ng-container>

--- a/ui/src/app/job-details/tabs/tabs.component.html
+++ b/ui/src/app/job-details/tabs/tabs.component.html
@@ -79,33 +79,12 @@
         <ng-container matColumnDef="files">
           <mat-header-cell *matHeaderCellDef> Log files </mat-header-cell>
           <mat-cell *matCellDef="let t" class="column">
-            <clr-tooltip *ngIf="getResourceUrl(t.stdout)">
-              <a class="log-item" href="{{ getResourceUrl(t.stdout) }}" target="_blank">
-                <clr-icon clrTooltipTrigger shape="file" size="24" style="color:#5C912E"></clr-icon>
-                <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-                  <span>stdout log</span>
-                </clr-tooltip-content>
-              </a>
-            </clr-tooltip>
-            <clr-icon *ngIf="!getResourceUrl(t.stdout)" shape="file" size="24" style="color: #ccc;"></clr-icon>
-            <clr-tooltip *ngIf="getResourceUrl(t.stderr)">
-              <a class="log-item" href="{{ getResourceUrl(t.stderr) }}" target="_blank">
-                <clr-icon clrTooltipTrigger shape="file" size="24" class="has-alert log-error" style="color:#5C912E"></clr-icon>
-                <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-                  <span>stderr log</span>
-                </clr-tooltip-content>
-              </a>
-            </clr-tooltip>
-            <clr-icon *ngIf="!getResourceUrl(t.stderr)" shape="file" size="24" class="has-alert log-error disabled" style="color: #ccc;"></clr-icon>
-            <clr-tooltip *ngIf="getTaskDirectory(t)">
-              <a class="log-item" href="{{ getTaskDirectory(t) }}" target="_blank">
-                <clr-icon clrTooltipTrigger shape="folder" size="24" class="is-solid" style="color:#5C912E"></clr-icon>
-                <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-                  <span>execution directory</span>
-                </clr-tooltip-content>
-              </a>
-            </clr-tooltip>
-            <clr-icon *ngIf="!getTaskDirectory(t)" shape="folder" size="24" style="color: #ccc;"></clr-icon>
+            <jm-debug-icons [displayMessage]="false"
+                            [message]="t.failure"
+                            [stdout]="t.stdout"
+                            [stderr]="t.stderr"
+                            [directory]="t.callRoot">
+            </jm-debug-icons>
           </mat-cell>
         </ng-container>
 

--- a/ui/src/app/job-details/tabs/tabs.component.spec.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.spec.ts
@@ -15,6 +15,7 @@ import {Ng2GoogleChartsModule} from 'ng2-google-charts';
 
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {JobFailuresTableComponent} from '../common/failures-table/failures-table.component';
+import {JobDebugIconsComponent} from "../common/debug-icons/debug-icons.component";
 import {AuthService} from '../../core/auth.service';
 import {JobMetadataResponse} from '../../shared/model/JobMetadataResponse';
 import {JobStatus} from '../../shared/model/JobStatus';
@@ -56,6 +57,7 @@ describe('JobTabsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        JobDebugIconsComponent,
         JobTabsComponent,
         JobFailuresTableComponent,
         JobResourcesTableComponent,

--- a/ui/src/app/job-details/tabs/tabs.component.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.ts
@@ -16,7 +16,6 @@ import {AuthService} from '../../core/auth.service';
 import {JobMetadataResponse} from '../../shared/model/JobMetadataResponse';
 import {JobStatus} from '../../shared/model/JobStatus';
 import {JobStatusIcon} from '../../shared/common';
-import {ResourceUtils} from '../../shared/utils/resource-utils';
 import {TaskMetadata} from '../../shared/model/TaskMetadata';
 import {JobFailuresTableComponent} from "../common/failures-table/failures-table.component";
 import {JobTimingDiagramComponent} from "./timing-diagram/timing-diagram.component";
@@ -67,16 +66,6 @@ export class JobTabsComponent implements OnInit, OnChanges {
 
   getStatusIcon(status: JobStatus): string {
     return JobStatusIcon[status];
-  }
-
-  getResourceUrl(url: string): string {
-    return ResourceUtils.getDirectoryBrowserURL(url, this.authService.userEmail);
-  }
-
-  getTaskDirectory(task: TaskMetadata): string {
-    if (task.callRoot) {
-      return ResourceUtils.getDirectoryBrowserURL(task.callRoot);
-    }
   }
 
   hasCallCachedTask(): boolean {


### PR DESCRIPTION
Reduce possibility of certain icons behaving/linking in a different way dependent on context.

Closes #602 
Closes #609