### PR TITLE
Show sub-workflow error on parent workflow job details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Job Manager Change Log
 
+## v0.7.3 Release Notes
+
+### Elevated sub-workflow errors to the parent workflow error card on the Job Details page.
+
+#### Added a link to the sub-workflow in the error card.
+
 ## v0.7.2 Release Notes
 
 ### Improved the clarity of workflow-level errors.
@@ -9,7 +15,6 @@
 ### Fixed incorrect tooltip for standard out log.
 
 ### Added customized favicon.
->>>>>>> master
 
 ## v0.7.1 Release Notes
 

--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -656,6 +656,13 @@ definitions:
       callRoot:
         type: string
         description: If from a task, the root directory of the task or shard execution
+      jobId:
+        type: string
+        description: >
+          Id of the job corresponding to this task, if this task is a nested
+          child job. Expresses a child:parent relationship between this job
+          and the job containing this task.
+
   FieldType:
     type: string
     default: text

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -213,7 +213,8 @@ def format_task(task_name, task_metadata):
 
 def format_task_failure(task_name, metadata):
     return FailureMessage(task_name=remove_workflow_name(task_name),
-                          failure=_get_deepest_message(metadata.get('failures')),
+                          failure=get_deepest_message(
+                              metadata.get('failures')),
                           timestamp=_parse_datetime(metadata.get('end')),
                           stdout=metadata.get('stdout'),
                           stderr=metadata.get('stderr'),
@@ -443,9 +444,11 @@ def _get_execution_events(events):
         ]
     return execution_events
 
-def _get_deepest_message(metadata_list):
-    if 'causedBy' in metadata_list[0] and len(metadata_list[0].get('causedBy')):
-        return _get_deepest_message(metadata_list[0].get('causedBy'))
+
+def get_deepest_message(metadata_list):
+    if 'causedBy' in metadata_list[0] and len(
+            metadata_list[0].get('causedBy')):
+        return get_deepest_message(metadata_list[0].get('causedBy'))
     else:
         return metadata_list[0].get('message')
 

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -212,8 +212,18 @@ def format_task(task_name, task_metadata):
 
 
 def format_task_failure(task_name, metadata):
+    if 'failures' in metadata:
+        logger.warning('in first if')
+        failure = metadata['failures'][0]
+        if 'causedBy' in failure and len(failure['causedBy']):
+            logger.warning('in second if')
+            return format_task_failure(task_name, failure['causedBy'][0])
+    else:
+        logger.warning('in else')
+        failure = metadata
+
     return FailureMessage(task_name=remove_workflow_name(task_name),
-                          failure=metadata['failures'][0].get('message'),
+                          failure=failure.get('message'),
                           timestamp=_parse_datetime(metadata.get('end')),
                           stdout=metadata.get('stdout'),
                           stderr=metadata.get('stderr'),

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -591,6 +591,50 @@ class TestJobsController(BaseTestCase):
         self.assertDictEqual(response_data, expected_data)
 
     @requests_mock.mock()
+    def test_nested_message_is_returned(self, mock_request):
+        """
+        Test case for get_deepest_message
+
+        Deepest error message gets returned instead of highest-level message
+        """
+        top_level_message = [{
+            'causedBy': [],
+            'message': 'This is the right message to return'
+        }]
+
+        second_level_message = [{
+            'causedBy': [{
+                'causedBy': [],
+                'message': 'This is the right message to return'
+            }],
+            'message':
+            'Workflow failed'
+        }]
+
+        third_level_message = [{
+            'causedBy': [{
+                'causedBy': [{
+                    'causedBy': [],
+                    'message': 'This is the right message to return'
+                }],
+                'message':
+                'This is the wrong message to return'
+            }],
+            'message':
+            'Workflow failed'
+        }]
+
+        self.assertEqual(
+            'This is the right message to return',
+            jobs_controller.get_deepest_message(top_level_message))
+        self.assertEqual(
+            jobs_controller.get_deepest_message(top_level_message),
+            jobs_controller.get_deepest_message(second_level_message))
+        self.assertEqual(
+            jobs_controller.get_deepest_message(second_level_message),
+            jobs_controller.get_deepest_message(third_level_message))
+
+    @requests_mock.mock()
     def test_get_job_bad_request(self, mock_request):
         workflow_id = 'id'
         error_message = 'Invalid workflow ID: {}.'.format(workflow_id)

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.css
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.css
@@ -1,4 +1,4 @@
-clr-tooltip-content {
+clr-tooltip-content.message {
   background-color: rgba(0, 0, 0, 0.65);
   padding: 0.25rem 0.5rem;
   font-size: 0.65rem;
@@ -7,7 +7,10 @@ clr-tooltip-content {
   margin: -0.6rem 0.5rem 0 0;
   height: auto;
   line-height: 1rem;
+  overflow-wrap: break-word;
+  max-width: 30rem;
 }
+
 
 clr-tooltip a {
   text-decoration: none;

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.css
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.css
@@ -98,3 +98,12 @@ td.failure-links {
   min-width: 107px;
   padding-right: 0px;
 }
+
+.title-link {
+  color: black;
+}
+
+a.title-link {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.html
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.html
@@ -3,7 +3,10 @@
   <!-- Task name column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef class="failure-task"> Task Name </th>
-    <td mat-cell *matCellDef="let f" class="failure-task">{{ f.taskName }}</td>
+    <td mat-cell *matCellDef="let f" class="failure-task">
+      <a class="title-link" *ngIf="f.jobId" href="/jobs/{{f.jobId}}">{{ f.taskName }}</a>
+      <span *ngIf="!f.jobId">{{ f.taskName }}</span>
+    </td>
   </ng-container>
 
   <!-- Failure message column -->

--- a/ui/src/app/job-details/job-details.component.css
+++ b/ui/src/app/job-details/job-details.component.css
@@ -3,4 +3,5 @@
   width: 100%;
   top: 66px;
   bottom: 0;
+  overflow: hidden;
 }

--- a/ui/src/app/job-details/panels/panels.component.css
+++ b/ui/src/app/job-details/panels/panels.component.css
@@ -4,8 +4,9 @@ p {
 }
 
 .content {
-  margin: 0 1rem 1rem 1rem;
+  margin: 0 0 1rem 1rem;
   padding-top: 2rem;
+  min-width: 57rem;
 }
 
 .header {
@@ -26,14 +27,14 @@ p {
 
 .mat-card-title {
   font-size: 1.1rem;
-  color: gray
+  color: gray;
 }
 
 .card {
   float: left;
   width: 18rem;
   height: 11rem;
-  margin: 1rem 1rem 3rem 1rem;
+  margin: 1rem 1rem 2rem 0px;
   border-radius: 5px;
   box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 3px 2px 0 rgba(0,0,0,0.12);
   padding: 0 0 24px 0;

--- a/ui/src/app/job-details/panels/panels.component.html
+++ b/ui/src/app/job-details/panels/panels.component.html
@@ -24,54 +24,54 @@
       <span *ngIf="job.labels[l] != ''">{{ l + ': '}}<b>{{ job.labels[l] }}</b></span>
     </span>
   </div>
-</div>
 
-<mat-card class="card">
-  <mat-card-title>Status: <span class="job-status">{{ job.status }}</span>
-    <clr-icon [attr.shape]="getStatusIcon(job.status)" size="20"></clr-icon>
-  </mat-card-title>
-  <mat-card-content>
-    <p><b>
-      <ng-container *ngIf="numTasks > 0">
-        Tasks: {{ numSucceededTasks }} succeeded, {{ numFailedTasks }} failed, {{ numRunningTasks }} currently being processed
-      </ng-container>
-    </b></p>
-    <p id="submitted" *ngIf="job.submission">
-      Submitted:
-      <jm-datetime [datetime]="job.submission"></jm-datetime>
-    </p>
-    <p id="started" *ngIf="job.start">
-      Started:
-      <jm-datetime [datetime]="job.start"></jm-datetime>
-    </p>
-    <p id="ended" *ngIf="job.end">
-      Ended:
-      <jm-datetime [datetime]="job.end"></jm-datetime>
-      ({{ job.start | jmDuration: job.end }})
-    </p>
-  </mat-card-content>
-</mat-card>
-
-<mat-card class="card" *ngIf="whiteListedExtensions().length > 0">
-  <mat-card-title>Details</mat-card-title>
-  <mat-card-content>
-    <div *ngFor="let f of whiteListedExtensions()">
-      <p class="detail-field">
-        <!--TODO(bryancrampton): Format dates correctly here-->
-        <span>{{ f + ': ' + job.extensions[f] }}</span>
+  <mat-card class="card">
+    <mat-card-title>Status: <span class="job-status">{{ job.status }}</span>
+      <clr-icon [attr.shape]="getStatusIcon(job.status)" size="20"></clr-icon>
+    </mat-card-title>
+    <mat-card-content>
+      <p><b>
+        <ng-container *ngIf="numTasks > 0">
+          Tasks: {{ numSucceededTasks }} succeeded, {{ numFailedTasks }} failed, {{ numRunningTasks }} currently being processed
+        </ng-container>
+      </b></p>
+      <p id="submitted" *ngIf="job.submission">
+        Submitted:
+        <jm-datetime [datetime]="job.submission"></jm-datetime>
       </p>
-    </div>
-  </mat-card-content>
-</mat-card>
+      <p id="started" *ngIf="job.start">
+        Started:
+        <jm-datetime [datetime]="job.start"></jm-datetime>
+      </p>
+      <p id="ended" *ngIf="job.end">
+        Ended:
+        <jm-datetime [datetime]="job.end"></jm-datetime>
+        ({{ job.start | jmDuration: job.end }})
+      </p>
+    </mat-card-content>
+  </mat-card>
 
-<mat-card class="card" *ngIf="hasFailures()">
-  <mat-card-title>Errors ({{ job.failures.length }} total)</mat-card-title>
-  <mat-card-content>
-    <jm-failures-table [failures]="job.failures"
-                       [numToShow]="numOfErrorsToShow"
-                       [showHeaders]="false"
-                       [displayedColumns]="['name','links']"
-                       [context]="'card'">
-    </jm-failures-table>
-  </mat-card-content>
-</mat-card>
+  <mat-card class="card" *ngIf="whiteListedExtensions().length > 0">
+    <mat-card-title>Details</mat-card-title>
+    <mat-card-content>
+      <div *ngFor="let f of whiteListedExtensions()">
+        <p class="detail-field">
+          <!--TODO(bryancrampton): Format dates correctly here-->
+          <span>{{ f + ': ' + job.extensions[f] }}</span>
+        </p>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card class="card" *ngIf="hasFailures()">
+    <mat-card-title>Errors ({{ job.failures.length }} total)</mat-card-title>
+    <mat-card-content>
+      <jm-failures-table [failures]="job.failures"
+                         [numToShow]="numOfErrorsToShow"
+                         [showHeaders]="false"
+                         [displayedColumns]="['name','links']"
+                         [context]="'card'">
+      </jm-failures-table>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/ui/src/app/job-details/tabs/tabs.component.css
+++ b/ui/src/app/job-details/tabs/tabs.component.css
@@ -1,6 +1,7 @@
 .content {
   margin: 1rem;
   clear: left;
+  min-width: 56rem;
 }
 
 mat-expansion-panel {

--- a/ui/src/app/job-details/tabs/tabs.component.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.ts
@@ -66,14 +66,14 @@ export class JobTabsComponent implements OnInit, OnChanges {
   }
 
   hasCallCachedTask(): boolean {
-    if (this.tasks.find(t => t.callCached === true)) {
+    if (this.tasks && this.tasks.find(t => t.callCached === true)) {
       return true;
     }
     return false;
   }
 
   hasScatteredTask(): boolean {
-    if (this.tasks.find(t => t.shards !== null)) {
+    if (this.tasks && this.tasks.find(t => t.shards !== null)) {
       return true;
     }
     return false;


### PR DESCRIPTION
Also, add link to sub-workflow from parent workflow error card.

Before:
![Screen Shot 2019-05-08 at 4 52 01 PM](https://user-images.githubusercontent.com/1713505/57407648-ae5d2200-71b1-11e9-8855-938f2b1171ef.png)

After:
![Screen Shot 2019-05-08 at 4 51 19 PM](https://user-images.githubusercontent.com/1713505/57407653-b0bf7c00-71b1-11e9-8d33-7e009192806b.png)
(on hover)
![Screen Shot 2019-05-08 at 4 51 27 PM](https://user-images.githubusercontent.com/1713505/57407657-b3ba6c80-71b1-11e9-822a-349352004f71.png)

Closes #635