### PR TITLE
Fix display of Clarity icons in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v0.7.3 Release Notes
+
+### Fixed the display of icons in Firefox.
+
 ## v0.7.2 Release Notes
 
 ### Improved the clarity of workflow-level errors.
@@ -9,7 +13,6 @@
 ### Fixed incorrect tooltip for standard out log.
 
 ### Added customized favicon.
->>>>>>> master
 
 ## v0.7.1 Release Notes
 

--- a/ui/src/polyfills.ts
+++ b/ui/src/polyfills.ts
@@ -41,6 +41,8 @@
 import 'core-js/es6/reflect';
 import 'core-js/es7/reflect';
 
+/** For Firefox support of Clarity Icons */
+import '@webcomponents/custom-elements/custom-elements.min.js';
 
 /**
  * Required to support Web Animations `@angular/animation`.


### PR DESCRIPTION
Fix suggested here: https://communities.vmware.com/message/2717325#2717325

Closes #639 