### PR TITLE
changed color of error message icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v0.7.3 Release Notes
+
+### Changed color of message icon from green to red to make it stand out more.
+
 ## v0.7.2 Release Notes
 
 ### Improved the clarity of workflow-level errors.
@@ -9,7 +13,6 @@
 ### Fixed incorrect tooltip for standard out log.
 
 ### Added customized favicon.
->>>>>>> master
 
 ## v0.7.1 Release Notes
 

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -1,7 +1,7 @@
 <div class="debug-icons">
   <clr-tooltip *ngIf="displayMessage">
     <a class="log-item">
-      <clr-icon clrTooltipTrigger shape="exclamation-triangle" size="24" style="color:#5C912E"></clr-icon>
+      <clr-icon clrTooltipTrigger shape="exclamation-triangle" size="24" style="color:#DB3214"></clr-icon>
       <clr-tooltip-content clrPosition="bottom-left" clrSize="xs" class="message" *clrIfOpen>
         <span>{{ message }}</span>
       </clr-tooltip-content>


### PR DESCRIPTION
Before:
![Screen Shot 2019-05-09 at 1 41 51 PM](https://user-images.githubusercontent.com/1713505/57474522-41ed2c00-7260-11e9-9f49-9c4ee71f3fde.png)


After:
![Screen Shot 2019-05-09 at 1 40 08 PM](https://user-images.githubusercontent.com/1713505/57474455-179b6e80-7260-11e9-870c-d6e0e9402e9d.png)

Closes #634 