### PR TITLE
Gracefully handle tasks with no start datetime [BA-4978]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v1.2.1 Release Notes
+
+### Added logic to avoid 500 error on Job Details page when a task does not have a start time.
+
 ## v1.2.0 Release Notes
 
 ### Added the ability – with the addition of a specific scope to the capabilities config file – to see the contents of Google Storage log files within the UI.

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -38,8 +38,7 @@ attempt_include_keys = ('attempt', 'callCaching:hit', 'callRoot', 'end',
 
 job_include_keys = attempt_include_keys + (
     'calls', 'description', 'executionEvents', 'labels', 'parentWorkflowId',
-    'returnCode', 'shardIndex', 'start', 'status', 'submission',
-    'subWorkflowId', 'workflowName')
+    'returnCode', 'status', 'submission', 'subWorkflowId', 'workflowName')
 
 
 @requires_auth
@@ -278,7 +277,7 @@ def format_task(task_name, task_metadata):
         execution_status=task_statuses.cromwell_execution_to_api(
             latest_attempt.get('executionStatus')),
         start=_parse_datetime(latest_attempt.get('start'))
-        or datetime.utcnow(),
+        or _parse_datetime(latest_attempt.get('end')) or datetime.utcnow(),
         end=_parse_datetime(latest_attempt.get('end')),
         stderr=latest_attempt.get('stderr'),
         stdout=latest_attempt.get('stdout'),


### PR DESCRIPTION
Make sure that a missing `start` time in a task will not result in weird or broken behavior by changing the fallback value from `now()` to `end`.

Closes https://broadworkbench.atlassian.net/browse/BA-4978.