### PR TITLE
fix redirect bug [BA-5793]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v1.3.2 Release Notes
+
+### Fixed a bug that needlessly redirected a user to the Sign In page before every page load.
+
 ## v1.3.1 Release Notes
 
 ### Fixed a bug where clicking on operation details icon will show attempt data.

--- a/ui/src/app/core/auth.service.ts
+++ b/ui/src/app/core/auth.service.ts
@@ -11,7 +11,7 @@ declare const gapi: any;
 /** Service wrapper for google oauth2 state and starting sign-in flow. */
 @Injectable()
 export class AuthService {
-  private initAuthPromise: Promise<void>;
+  public initAuthPromise: Promise<void>;
   public authenticated = new BehaviorSubject<boolean>(false);
   public authToken: string;
   public userId: string;

--- a/ui/src/app/core/capabilities-activator.service.ts
+++ b/ui/src/app/core/capabilities-activator.service.ts
@@ -18,24 +18,24 @@ export class CapabilitiesActivator implements CanActivate {
     private readonly capabilitiesService: CapabilitiesService,
     private readonly router: Router) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
-    return this.capabilitiesService.getCapabilities()
-      .then(cap => this.handleAuthCapabilities(cap, route.routeConfig.path, state.url))
-      .then(cap => this.handleProjectCapabilities(cap, route))
-      .catch(error => {
-        // Handle all not-activated errors by just returning false for
-        // this promise. All others, re-throw.
-        if (error == CapabilitiesActivator.notActivatedError) {
-          return false;
-        }
-        throw error;
-      });
+  async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
+    try {
+      const cap = await this.handleAuthCapabilities(await this.capabilitiesService.getCapabilities(), route.routeConfig.path, state.url);
+      return this.handleProjectCapabilities(cap, route);
+    } catch (error) {
+      // Handle all not-activated errors by just returning false for
+      // this promise. All others, re-throw.
+      if (error == CapabilitiesActivator.notActivatedError) {
+        return false;
+      }
+      throw error;
+    }
   }
 
-  private handleAuthCapabilities(capabilities: CapabilitiesResponse, path: String, url: String): Promise<CapabilitiesResponse>|CapabilitiesResponse {
+  private handleAuthCapabilities(capabilities: CapabilitiesResponse, path: String, url: String): Promise<CapabilitiesResponse> {
     if (capabilities.authentication && capabilities.authentication.isRequired) {
       if (this.authService.authenticated.getValue() || path == 'sign_in') {
-        return capabilities;
+        return Promise.resolve(capabilities);
       }
 
       return this.authService.initAuthPromise.then( () => {
@@ -53,7 +53,7 @@ export class CapabilitiesActivator implements CanActivate {
       this.router.navigate(['']);
       throw CapabilitiesActivator.notActivatedError;
     }
-    return capabilities;
+    return Promise.resolve(capabilities);
   }
 
   private handleProjectCapabilities(capabilities: CapabilitiesResponse, route: ActivatedRouteSnapshot): boolean {

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
@@ -40,7 +40,7 @@ export class JobDebugIconsComponent implements OnInit {
 
   ngOnInit(): void {
     try {
-      const authenticated = this.authService.isAuthenticated()
+      const authenticated = this.authService.isAuthenticated();
       if (authenticated && this.authService.gcsReadAccess) {
         if (this.stdout) {
           this.getLogContents(this.stdout).then((value) => {


### PR DESCRIPTION
Sorted out order of operations for auth and capabilities services so that user is not redirected to the log in screen unnecessarily.

Closes https://broadworkbench.atlassian.net/browse/BA-5793