### PR TITLE
Show errors tab by default in certain circumstances [BA-5893]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added the ability -- if Job Manager is being run with access to a SAM server -- to see the contents of Google Storage log files within the UI.
 
+### If a job has finished running and there are errors, default to the "Errors" tab on the Job Details page.
+
 ## v1.4.1 Release Notes
 
 ### Fixed a bug that caused Job Manager to throw a 500 error when it attempted to process a scattered task shard with no end time.

--- a/ui/src/app/job-details/tabs/tabs.component.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.ts
@@ -1,28 +1,18 @@
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-  ViewChild
-} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {MatDialog} from "@angular/material";
 import {Observable} from 'rxjs/Observable';
 
 import {JobMetadataResponse} from '../../shared/model/JobMetadataResponse';
 import {JobStatus} from '../../shared/model/JobStatus';
-import {JobStatusIcon} from '../../shared/common';
+import {JobStatusIcon, objectNotEmpty} from '../../shared/common';
 import {TaskMetadata} from '../../shared/model/TaskMetadata';
 import {JobFailuresTableComponent} from "../common/failures-table/failures-table.component";
 import {JobTimingDiagramComponent} from "./timing-diagram/timing-diagram.component";
 import {JobManagerService} from "../../core/job-manager.service";
 import {Shard} from "../../shared/model/Shard";
 import {JobScatteredAttemptsComponent} from "./scattered-attempts/scattered-attempts.component";
-import {objectNotEmpty} from '../../shared/common';
 
 @Component({
   selector: 'jm-tabs',
@@ -50,6 +40,10 @@ export class JobTabsComponent implements OnInit, OnChanges {
     this.dataSource = new TasksDataSource(this.database);
     if (this.tabsPanel) {
       this.tabWidth = this.tabsPanel._viewContainerRef.element.nativeElement.clientWidth;
+    }
+    // select the 'Errors' tab to be the default if the job has finished, failed and has errors
+    if ((this.job.status == JobStatus.Failed || this.job.status == JobStatus.Aborted) && this.hasFailures() && this.hasTasks()) {
+      this.selectedTab = 1;
     }
   }
 


### PR DESCRIPTION
Default to Errors tab if job has failed or been aborted and there are error messages.

Closes https://broadworkbench.atlassian.net/browse/BA-5893.