### PR TITLE
Display only the backend log (no more stdout and stderr) [BA-5907]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v1.5.2 Release Notes
+
+### Removed `stdout` and `stderr` logs for Cromwell, since their contents are included in the `backend log`.  Also increased the maximum amount of content for the `backend log` to 500KB.
+
 ## v1.5.1 Release Notes
 
 ### Added a link to the top-level execution directory for the job.

--- a/api/jobs.yaml
+++ b/api/jobs.yaml
@@ -749,12 +749,6 @@ definitions:
       returnCode:
         type: integer
         description: Task execution return code
-      stdout:
-        type: string
-        description: Path to the standard output file for this task
-      stderr:
-        type: string
-        description: Path to the standard error file for this task
       backendLog:
         type: string
         description: Path to the backend log file for this task
@@ -798,12 +792,6 @@ definitions:
         type: boolean
         description: A flag to indicate if task was call-cached.
         default: false
-      stdout:
-        type: string
-        description: Path to the standard output file for this task
-      stderr:
-        type: string
-        description: Path to the standard error file for this task
       backendLog:
         type: string
         description: Path to the backend log file for this task
@@ -856,12 +844,6 @@ definitions:
         description: End datetime of the task execution in ISO8601 format with milliseconds
       shardIndex:
         type: integer
-      stdout:
-        type: string
-        description: If from a task, path to the standard output file for this task or shard
-      stderr:
-        type: string
-        description: If from a task, path to the standard error file for this task or shard
       backendLog:
         type: string
         description: If from a task, path to the backend log file for this task or shard
@@ -908,12 +890,6 @@ definitions:
         type: string
         format: date-time
         description: The time at which this failure occurred
-      stdout:
-        type: string
-        description: If from a task, path to the standard output file for this task or shard
-      stderr:
-        type: string
-        description: If from a task, path to the standard error file for this task or shard
       backendLog:
         type: string
         description: If from a task, path to the backend log file for this task or shard

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -351,8 +351,6 @@ def format_scattered_task(task_name, task_metadata):
                       or _parse_datetime(shard.get('end')) or offset_aware_now,
                       end=_parse_datetime(shard.get('end')),
                       shard_index=shard.get('shardIndex'),
-                      execution_events=_get_execution_events(
-                          shard.get('executionEvents')),
                       backend_log=shard.get('backendLogs').get('log')
                       if shard.get('backendLogs') else None,
                       call_root=shard.get('callRoot'),

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -89,8 +89,7 @@ class TestJobsController(BaseTestCase):
             'test.analysis.outputs': 'gs://project-bucket/test/outputs.txt'
         }
         labels = {}
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         attempts = 1
         return_code = 0
 
@@ -109,8 +108,7 @@ class TestJobsController(BaseTestCase):
                         'executionStatus': 'Done',
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLog': backend_log,
                         'returnCode': return_code,
                         'inputs': inputs,
                         'outputs': outputs,
@@ -169,8 +167,7 @@ class TestJobsController(BaseTestCase):
             "existing_test_label1": "existing_test_label_value1",
             "existing_test_label2": "existing_test_label_value2"
         }
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         attempts = 1
         return_code = 0
 
@@ -195,8 +192,7 @@ class TestJobsController(BaseTestCase):
                         'executionStatus': 'Done',
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLog': backend_log,
                         'returnCode': return_code,
                         'inputs': inputs,
                         'attempt': attempts
@@ -358,8 +354,7 @@ class TestJobsController(BaseTestCase):
             'test.analysis.outputs': 'gs://project-bucket/test/outputs.txt'
         }
         labels = {'cromwell-workflow-id': 'cromwell-12345'}
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         attempts = 1
         return_code = 0
 
@@ -375,8 +370,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': -1,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'returnCode': return_code,
                         'inputs': inputs,
                         'outputs': outputs,
@@ -424,8 +419,7 @@ class TestJobsController(BaseTestCase):
                     'executionStatus': 'Succeeded',
                     'start': response_timestamp,
                     'end': response_timestamp,
-                    'stderr': std_err,
-                    'stdout': std_out,
+                    'backendLog': backend_log,
                     'callCached': False,
                     'inputs': jobs_controller.update_key_names(inputs),
                     'outputs': jobs_controller.update_key_names(outputs),
@@ -459,8 +453,7 @@ class TestJobsController(BaseTestCase):
             'test.analysis.outputs': 'gs://project-bucket/test/outputs.txt'
         }
         labels = {'cromwell-workflow-id': 'cromwell-12345'}
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         attempts = 1
         return_code = 0
 
@@ -528,8 +521,7 @@ class TestJobsController(BaseTestCase):
         }
         labels = {'cromwell-workflow-id': 'cromwell-12345'}
         call_root = '/cromwell/cromwell-executions/id/call-analysis'
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         attempts = 2
         return_code = 0
 
@@ -545,8 +537,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': 0,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'callRoot': call_root,
                         'returnCode': return_code,
                         'inputs': inputs,
@@ -562,8 +554,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': 1,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'callRoot': call_root,
                         'returnCode': return_code,
                         'inputs': inputs,
@@ -618,15 +610,13 @@ class TestJobsController(BaseTestCase):
             'failures': [{
                 'callRoot': call_root,
                 'failure': 'test.analysis shard 0 failed',
-                'stderr': std_err,
-                'stdout': std_out,
+                'backendLog': backend_log,
                 'taskName': 'analysis',
                 'timestamp': response_timestamp
             },{
                 'callRoot': call_root,
                 'failure': 'test.analysis shard 1 failed',
-                'stderr': std_err,
-                'stdout': std_out,
+                'backendLog': backend_log,
                 'taskName': 'analysis',
                 'timestamp': response_timestamp
             }],
@@ -643,8 +633,7 @@ class TestJobsController(BaseTestCase):
                         'attempts': attempts,
                         'end': response_timestamp,
                         'callRoot': call_root,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLog': backend_log,
                         'executionStatus': 'Failed',
                         'failureMessages': ['test.analysis shard 0 failed'],
                         'shardIndex': 0,
@@ -653,8 +642,7 @@ class TestJobsController(BaseTestCase):
                         'attempts': attempts,
                         'end': response_timestamp,
                         'callRoot': call_root,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLog': backend_log,
                         'executionStatus': 'Failed',
                         'failureMessages': ['test.analysis shard 1 failed'],
                         'shardIndex': 1,
@@ -684,8 +672,7 @@ class TestJobsController(BaseTestCase):
         }
         labels = {'cromwell-workflow-id': 'cromwell-12345'}
         call_root = '/cromwell/cromwell-executions/id/call-analysis'
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         return_code = 0
 
         def _request_callback(request, context):
@@ -700,8 +687,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': -1,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'returnCode': return_code,
                         'inputs': inputs,
                         'outputs': outputs,
@@ -716,8 +703,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': -1,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'returnCode': return_code,
                         'inputs': inputs,
                         'outputs': outputs,
@@ -764,8 +751,7 @@ class TestJobsController(BaseTestCase):
                 'executionStatus': 'Failed',
                 'inputs': inputs,
                 'outputs': outputs,
-                'stderr': std_err,
-                'stdout': std_out
+                'backendLog': backend_log
             },{
                 'attemptNumber': 2,
                 'callCached': 'False',
@@ -775,8 +761,7 @@ class TestJobsController(BaseTestCase):
                 'executionStatus': 'Succeeded',
                 'inputs': inputs,
                 'outputs': outputs,
-                'stderr': std_err,
-                'stdout': std_out
+                'backendLog': backend_log
             }]
         }  # yapf: disable
         self.assertDictEqual(response_data, expected_data)
@@ -800,8 +785,7 @@ class TestJobsController(BaseTestCase):
         }
         labels = {'cromwell-workflow-id': 'cromwell-12345'}
         call_root = '/cromwell/cromwell-executions/id/call-analysis'
-        std_err = '/cromwell/cromwell-executions/id/call-analysis/stderr'
-        std_out = '/cromwell/cromwell-executions/id/call-analysis/stdout'
+        backend_log = '/cromwell/cromwell-executions/id/call-analysis/call-analysis-log'
         return_code = 0
 
         def _request_callback(request, context):
@@ -816,8 +800,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': 0,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'returnCode': return_code,
                         'inputs': inputs,
                         'outputs': outputs,
@@ -832,8 +816,8 @@ class TestJobsController(BaseTestCase):
                         'shardIndex': 0,
                         'start': timestamp,
                         'end': timestamp,
-                        'stderr': std_err,
-                        'stdout': std_out,
+                        'backendLogs': {
+                            'log': backend_log},
                         'returnCode': return_code,
                         'inputs': inputs,
                         'outputs': outputs,
@@ -882,8 +866,7 @@ class TestJobsController(BaseTestCase):
                 'executionStatus': 'Failed',
                 'inputs': inputs,
                 'outputs': outputs,
-                'stderr': std_err,
-                'stdout': std_out
+                'backendLog': backend_log
             },{
                 'attemptNumber': 2,
                 'callCached': 'False',
@@ -893,8 +876,7 @@ class TestJobsController(BaseTestCase):
                 'executionStatus': 'Succeeded',
                 'inputs': inputs,
                 'outputs': outputs,
-                'stderr': std_err,
-                'stdout': std_out
+                'backendLog': backend_log
             }]
         }  # yapf: disable
         self.assertDictEqual(response_data, expected_data)

--- a/ui/src/app/job-details/common/attempt/attempt.component.css
+++ b/ui/src/app/job-details/common/attempt/attempt.component.css
@@ -72,7 +72,7 @@ mat-expansion-panel.mat-expansion-panel .task-start {
 }
 
 mat-expansion-panel.mat-expansion-panel .task-links {
-  width: 11.25rem;
+  width: 9.25rem;
 }
 
 :host-context(mat-accordion.mat-accordion.content) mat-expansion-panel.mat-expansion-panel .task-start {
@@ -80,7 +80,7 @@ mat-expansion-panel.mat-expansion-panel .task-links {
 }
 
 :host-context(mat-accordion.mat-accordion.content) mat-expansion-panel.mat-expansion-panel .task-links {
-  width: 10.625rem;
+  width: 8.625rem;
 }
 
 mat-expansion-panel.mat-expansion-panel .task-status,

--- a/ui/src/app/job-details/common/attempt/attempt.component.html
+++ b/ui/src/app/job-details/common/attempt/attempt.component.html
@@ -55,8 +55,6 @@
                         [operationId]="attempt.operationId"
                         [jobId]="jobId"
                         [message]="getFailures(attempt)"
-                        [stdout]="attempt.stdout"
-                        [stderr]="attempt.stderr"
                         [backendLog]="attempt.backendLog"
                         [directory]="attempt.callRoot">
         </jm-debug-icons>

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -6,24 +6,6 @@
       </clr-tooltip-content>
     </a>
   </clr-tooltip>
- <clr-icon *ngIf="!getResourceUrl(stdout)" shape="file" class="disabled"></clr-icon>
-  <clr-tooltip *ngIf="getResourceUrl(stdout)">
-    <button class="log-item" (click)="showOrLinkTo($event, stdout)">
-      <clr-icon clrTooltipTrigger shape="file"></clr-icon>
-      <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-        <span>stdout log</span>
-      </clr-tooltip-content>
-    </button>
-  </clr-tooltip>
-  <clr-icon *ngIf="!getResourceUrl(stderr)" shape="file" class="has-alert log-error disabled"></clr-icon>
-  <clr-tooltip *ngIf="getResourceUrl(stderr)">
-    <button class="log-item" (click)="showOrLinkTo($event, stderr)">
-      <clr-icon clrTooltipTrigger shape="file" class="has-alert log-error"></clr-icon>
-      <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
-        <span>stderr log</span>
-      </clr-tooltip-content>
-    </button>
-  </clr-tooltip>
   <mat-icon *ngIf="!getResourceUrl(backendLog)" svgIcon="cloud-file" class="disabled"></mat-icon>
   <clr-tooltip *ngIf="getResourceUrl(backendLog)">
     <button class="log-item" (click)="showOrLinkTo($event, backendLog)">

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
@@ -22,8 +22,7 @@ describe('JobDebugIconsComponent', () => {
   let sanitizer;
   let job = {
     failure: 'things went wrong',
-    stdout : 'gs://test-bucket/test-job/stdout.txt',
-    stderr: 'gs://test-bucket/test-job/stderr.txt',
+    backendLog: 'gs://test-bucket/test-log.txt',
     callRoot: 'gs://test-bucket/test-job'
   };
   let fakeCapabilitiesService =  new FakeCapabilitiesService({});
@@ -76,15 +75,9 @@ describe('JobDebugIconsComponent', () => {
     expect(de.queryAll(By.css('clr-icon[shape=exclamation-triangle]')).length).toEqual(1);
   }));
 
-  it('should calculate the right location for stdout', async(() => {
+  it('should calculate the right location for backend log', async(() => {
     fixture.detectChanges();
-    expect(testComponent.jobDebugIconsComponent.getResourceUrl(job.stdout) == 'https://console.cloud.google.com/storage/browser/test-bucket/test-job?prefix=stdout.txt');
-  }));
-
-  it('should calculate the right location for stderr', async(() => {
-    fixture.detectChanges();
-    let de: DebugElement = fixture.debugElement;
-    expect(testComponent.jobDebugIconsComponent.getResourceUrl(job.stderr) == 'https://console.cloud.google.com/storage/browser/test-bucket/test-job?prefix=stderr.txt');
+    expect(testComponent.jobDebugIconsComponent.getResourceUrl(job.backendLog) == 'https://console.cloud.google.com/storage/browser/test-bucket/test-job?prefix=test-log.txt');
   }));
 
   it('should link to the right location for execution directory', async(() => {
@@ -98,8 +91,7 @@ describe('JobDebugIconsComponent', () => {
     template: `<jm-debug-icons [displayMessage]="false"
                                [jobId]=""
                                [message]="job.failure"
-                               [stdout]="job.stdout"
-                               [stderr]="job.stderr"
+                               [backendLog]="job.backendLog"
                                [directory]="job.callRoot"></jm-debug-icons>`
   })
   class TestDebugIconsComponent {

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
@@ -23,8 +23,6 @@ export class JobDebugIconsComponent implements OnInit {
   @Input() operationId: string;
   @Input() jobId: string;
   @Input() message: string;
-  @Input() stdout: string;
-  @Input() stderr: string;
   @Input() backendLog: string;
   @Input() directory: string;
   logFileData: Map<string, string> = new Map();
@@ -46,20 +44,6 @@ export class JobDebugIconsComponent implements OnInit {
   ngOnInit(): void {
     try {
       if (this.authService.isAuthenticated() && this.canGetFileContents) {
-        if (this.stdout) {
-          this.getLogContents(this.stdout).then((value) => {
-            this.logFileData[this.getFileName(this.stdout)] = value;
-          }).catch(error => {
-            this.handleError(error);
-          });
-        }
-        if (this.stderr) {
-          this.getLogContents(this.stderr).then((value) => {
-            this.logFileData[this.getFileName(this.stderr)] = value;
-          }).catch(error => {
-            this.handleError(error);
-          });
-        }
         if (this.backendLog) {
           this.getLogContents(this.backendLog).then((value) => {
             this.logFileData[this.getFileName(this.backendLog)] = value;

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.css
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.css
@@ -58,7 +58,8 @@ td.failure-message {
 
 th.failure-links,
 td.failure-links {
-  min-width: 11.875em;
+  max-width: 7em;
+  min-width: 7em;
 }
 
 .log-item {
@@ -85,13 +86,14 @@ td.failure-links {
 }
 
 :host-context(mat-card.card) td.failure-task {
-  min-width: 6.25rem;
-  max-width: 6.25rem;
+  min-width: 9.75rem;
+  max-width: 9.75rem;
   font-size: 0.7rem;
 }
 
 :host-context(mat-card.card) td.failure-links {
-  min-width: 10rem;
+  min-width: 6rem;
+  max-width: 6rem;
   padding-right: 0px;
 }
 

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.html
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.html
@@ -23,8 +23,6 @@
                       [operationId]="f.operationId"
                       [jobId]="jobId"
                       [message]="f.failure"
-                      [stdout]="f.stdout"
-                      [stderr]="f.stderr"
                       [backendLog]="f.backendLog"
                       [directory]="f.callRoot">
       </jm-debug-icons>

--- a/ui/src/app/job-details/tabs/scattered-attempts/scattered-attempts.component.css
+++ b/ui/src/app/job-details/tabs/scattered-attempts/scattered-attempts.component.css
@@ -70,7 +70,7 @@ mat-expansion-panel.mat-expansion-panel .task-start {
 }
 
 mat-expansion-panel.mat-expansion-panel .task-links {
-  width: 10.625rem;
+  width: 8.625rem;
 }
 
 mat-expansion-panel.mat-expansion-panel.list-header .task-links {

--- a/ui/src/app/job-details/tabs/scattered-attempts/scattered-attempts.component.html
+++ b/ui/src/app/job-details/tabs/scattered-attempts/scattered-attempts.component.html
@@ -55,8 +55,6 @@
                               [operationId]="shard.operationId"
                               [jobId]="data.shardsData.taskId"
                               [message]="getFailures(shard)"
-                              [stdout]="shard.stdout"
-                              [stderr]="shard.stderr"
                               [backendLog]="shard.backendLog"
                               [directory]="shard.callRoot">
               </jm-debug-icons>

--- a/ui/src/app/job-details/tabs/tabs.component.css
+++ b/ui/src/app/job-details/tabs/tabs.component.css
@@ -85,7 +85,7 @@ mat-expansion-panel.mat-expansion-panel .task-start {
 }
 
 mat-expansion-panel.mat-expansion-panel .task-links {
-  width: 11.25rem;
+  width: 9.25rem;
 }
 
 mat-expansion-panel.mat-expansion-panel.list-header .task-links {

--- a/ui/src/app/job-details/tabs/tabs.component.html
+++ b/ui/src/app/job-details/tabs/tabs.component.html
@@ -107,8 +107,6 @@
                                     [operationId]="t.operationId"
                                     [jobId]="job.id"
                                     [message]="getTaskFailures(t)"
-                                    [stdout]="t.stdout"
-                                    [stderr]="t.stderr"
                                     [backendLog]="t.backendLog"
                                     [directory]="t.callRoot">
                     </jm-debug-icons>

--- a/ui/src/app/job-details/tabs/tabs.component.spec.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.spec.ts
@@ -53,8 +53,7 @@ describe('JobTabsComponent', () => {
     attempts: 1,
     returnCode: 0,
     callCached: false,
-    stderr: 'gs://test-bucket/stderr.txt',
-    stdout: 'gs://test-bucket/stdout.txt',
+    backendLog: 'gs://test-bucket/test-log.txt',
     callRoot: 'gs://test-bucket',
     inputs: {},
     outputs: {},
@@ -71,8 +70,7 @@ describe('JobTabsComponent', () => {
     attempts: 1,
     returnCode: 0,
     callCached: true,
-    stderr: 'gs://test-bucket/stderr.txt',
-    stdout: 'gs://test-bucket/stdout.txt',
+    backendLog: 'gs://test-bucket/test-log.txt',
     callRoot: 'gs://test-bucket',
     inputs: {},
     outputs: {},
@@ -88,8 +86,7 @@ describe('JobTabsComponent', () => {
     attempts: 1,
     returnCode: 0,
     callCached: false,
-    stderr: 'gs://test-bucket/stderr.txt',
-    stdout: 'gs://test-bucket/stdout.txt',
+    backendLog: 'gs://test-bucket/test-log.txt',
     callRoot: 'gs://test-bucket',
     inputs: {'string': 'hello world'},
     outputs: {},
@@ -105,8 +102,7 @@ describe('JobTabsComponent', () => {
     attempts: 1,
     returnCode: 0,
     callCached: false,
-    stderr: 'gs://test-bucket/stderr.txt',
-    stdout: 'gs://test-bucket/stdout.txt',
+    backendLog: 'gs://test-bucket/test-log.txt',
     callRoot: 'gs://test-bucket',
     inputs: {},
     outputs: {'string': 'hello world'},
@@ -122,8 +118,7 @@ describe('JobTabsComponent', () => {
     attempts: 2,
     returnCode: 0,
     callCached: false,
-    stderr: 'gs://test-bucket/stderr.txt',
-    stdout: 'gs://test-bucket/stdout.txt',
+    backendLog: 'gs://test-bucket/test-log.txt',
     callRoot: 'gs://test-bucket',
     inputs: {},
     outputs: {},
@@ -248,8 +243,7 @@ describe('JobTabsComponent', () => {
           'Task failed.'
         ],
         inputs: {},
-        stderr: 'gs://test-bucket/stderr.txt',
-        stdout: 'gs://test-bucket/stdout.txt',
+        backendLog: 'gs://test-bucket/test-log.txt'
       },{
         attemptNumber: 2,
         callRoot: 'gs://test-bucket/attempt-2',
@@ -258,8 +252,7 @@ describe('JobTabsComponent', () => {
         executionStatus: 'Succeeded',
         inputs: {},
         outputs: {},
-        stderr: 'gs://test-bucket/attempt-2/stderr.txt',
-        stdout: 'gs://test-bucket/attempt-2/stdout.txt',
+        backendLog: 'gs://test-bucket/attempt-2/test-log.txt'
       }
     ];
     taskWithTwoAttempts.attemptsData = attempts;

--- a/ui/src/app/job-details/tabs/tabs.component.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.ts
@@ -146,8 +146,6 @@ export class JobTabsComponent implements OnInit, OnChanges {
       let newShard: Shard = {};
       newShard.start = new Date(shard.start);
       newShard.end = new Date(shard.end);
-      newShard.stdout = shard.stdout;
-      newShard.stderr = shard.stderr;
       newShard.backendLog = shard.backendLog;
       newShard.callRoot = shard.callRoot;
       newShard.attempts = shard.attempts;


### PR DESCRIPTION
 - removed stdout and stderr logs, since the content is contained in the backend log
 - increased max size of backend log to 500KB

Before:
![Screen Shot 2019-08-21 at 12 21 14 PM](https://user-images.githubusercontent.com/1713505/63449903-ef9ada00-c40e-11e9-838c-357252c6e6ef.png)

After:
![Screen Shot 2019-08-21 at 12 17 27 PM](https://user-images.githubusercontent.com/1713505/63449912-f45f8e00-c40e-11e9-9764-eac3b1dd7789.png)

Closes https://broadworkbench.atlassian.net/browse/BA-5907