### PR TITLE
Handle parsing for task/shard attempts correctly [BA-5972]

### DIFF
--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -189,9 +189,16 @@ def get_task_attempts(id, task, **kwargs):
     job = response.json()
 
     attempts = [
-        _convert_to_attempt(call) for call in job.get('calls').get(task)
+        _convert_to_attempt(call)
+        for call in _get_calls_for_task(task, job.get('calls'))
     ]
     return JobAttemptsResponse(attempts=attempts)
+
+
+def _get_calls_for_task(task_name, calls):
+    for key, value in calls.items():
+        if key.endswith('.' + task_name):
+            return value
 
 
 @requires_auth
@@ -226,7 +233,8 @@ def get_shard_attempts(id, task, index, **kwargs):
     job = response.json()
 
     attempts = [
-        _convert_to_attempt(shard) for shard in job.get('calls').get(task)
+        _convert_to_attempt(shard)
+        for shard in _get_calls_for_task(task, job.get('calls'))
         if (shard.get('shardIndex') == int(index))
     ]
     return JobAttemptsResponse(attempts=attempts)

--- a/servers/cromwell/jobs/test/test_jobs_controller.py
+++ b/servers/cromwell/jobs/test/test_jobs_controller.py
@@ -666,7 +666,6 @@ class TestJobsController(BaseTestCase):
         """
         workflow_id = 'id'
         workflow_name = 'test'
-        task_name = 'test.task'
         status = 'Failed'
         timestamp = '2017-11-08T05:06:41.424Z'
         response_timestamp = '2017-11-08T05:06:41.424000+00:00'
@@ -686,7 +685,7 @@ class TestJobsController(BaseTestCase):
                 'id': workflow_id,
                 'status': status,
                 'calls': {
-                    task_name: [{
+                    'test.task': [{
                         'executionStatus': 'RetryableFailure',
                         'shardIndex': -1,
                         'start': timestamp,
@@ -741,7 +740,7 @@ class TestJobsController(BaseTestCase):
         mock_request.get(cromwell_url, json=_request_callback)
 
         response = self.client.open('/jobs/{id}/{task}/attempts'.format(
-            id=workflow_id, task=task_name),
+            id=workflow_id, task='task'),
                                     method='GET')
         self.assertStatus(response, 200)
         response_data = json.loads(response.data)
@@ -779,7 +778,6 @@ class TestJobsController(BaseTestCase):
         """
         workflow_id = 'id'
         workflow_name = 'test'
-        task_name = 'test.task'
         status = 'Failed'
         timestamp = '2017-11-08T05:06:41.424Z'
         response_timestamp = '2017-11-08T05:06:41.424000+00:00'
@@ -799,7 +797,7 @@ class TestJobsController(BaseTestCase):
                 'id': workflow_id,
                 'status': status,
                 'calls': {
-                    task_name: [{
+                    'test.task': [{
                         'executionStatus': 'RetryableFailure',
                         'shardIndex': 0,
                         'start': timestamp,
@@ -855,7 +853,7 @@ class TestJobsController(BaseTestCase):
 
         response = self.client.open(
             '/jobs/{id}/{task}/{index}/attempts'.format(id=workflow_id,
-                                                        task=task_name,
+                                                        task='task',
                                                         index=0),
             method='GET')
         self.assertStatus(response, 200)

--- a/ui/src/app/job-details/tabs/scattered-attempts/scattered-attempts.component.ts
+++ b/ui/src/app/job-details/tabs/scattered-attempts/scattered-attempts.component.ts
@@ -19,7 +19,8 @@ export class JobScatteredAttemptsComponent {
   }
 
   getShardAttempts(shard: Shard) {
-    this.jobManagerService.getShardAttempts(this.data.shardsData.taskId, this.data.shardsData.taskName, shard.shardIndex).then((response) => {
+    const simpleTaskName = this.data.shardsData.taskName.split('.')[1]
+    this.jobManagerService.getShardAttempts(this.data.shardsData.taskId, simpleTaskName, shard.shardIndex).then((response) => {
       shard.attemptsData = response.attempts;
     });
   }

--- a/ui/src/app/job-details/tabs/tabs.component.ts
+++ b/ui/src/app/job-details/tabs/tabs.component.ts
@@ -121,7 +121,7 @@ export class JobTabsComponent implements OnInit, OnChanges {
   }
 
   populateTaskAttempts(task: TaskMetadata) {
-    this.jobManagerService.getTaskAttempts(this.job.id, this.getJobTaskName(task.name)).then((response) => {
+    this.jobManagerService.getTaskAttempts(this.job.id, task.name).then((response) => {
       task.attemptsData = response.attempts;
     })
   }


### PR DESCRIPTION
With aliasing (e.g. `call subwf.subwf as alice`) there is no way to be sure of the full key for a task in the `calls` object in Cromwell metadata.  But the task name is always the same (e.g. the "taskName" in `alias.taskName`), so just check for that when getting attempts.

Closes https://broadworkbench.atlassian.net/browse/BA-5972