### PR TITLE
fixed display of workflow-level errors in error card [BA-6003]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.5.3 Release Notes
 
+### Fixed a bug where workflow-level errors are not displayed correctly in the Errors Card on the Job Details page.
+
+### Fixed a bug where certain task/sub-workflow attempts are not parsed correctly for the Job Details page.
+
 ### Leveraged `excludeKey` along with `includeKey` in Cromwell's metadata endpoint to remove extra information. This requires a version of Cromwell 43 or higher. 
 
 ## v1.5.2 Release Notes

--- a/ui/src/app/job-details/common/failures-table/failures-table.component.html
+++ b/ui/src/app/job-details/common/failures-table/failures-table.component.html
@@ -13,7 +13,7 @@
   <ng-container matColumnDef="shardIndex">
     <th mat-header-cell *matHeaderCellDef class="failure-shard"> Shard </th>
     <td mat-cell *matCellDef="let f" class="failure-shard">
-      <span *ngIf="f.shardIndex != '-1'"><span *ngIf="!displayedColumns.includes('message')">shard </span>{{ f.shardIndex }}</span>
+      <span *ngIf="f.shardIndex && (f.shardIndex != '-1')"><span *ngIf="!displayedColumns.includes('message')">shard </span>{{ f.shardIndex }}</span>
     </td>
   </ng-container>
 


### PR DESCRIPTION
Before:
![Screen Shot 2019-09-18 at 12 37 34 PM](https://user-images.githubusercontent.com/1713505/65168978-a640a900-da13-11e9-9bf6-331644cb0648.png)


Add:
![Screen Shot 2019-09-18 at 12 54 39 PM](https://user-images.githubusercontent.com/1713505/65168981-a80a6c80-da13-11e9-9872-cfd8fd3f3375.png)


Closes https://broadworkbench.atlassian.net/browse/BA-6003