### PR TITLE
fixed duration time for aborted scattered tasks [WA-79]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Job Manager Change Log
 
+## v1.5.5 Release Notes
+
+### Fixed a bug where aborted scattered tasks were displaying the incorrect duration in the Job Details page.
+
 ## v1.5.4 Release Notes
 
 ### Fixed a bug where workflow inputs/outputs were not always displayed correctly without browser reload.

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -376,7 +376,9 @@ def format_scattered_task(task_name, task_metadata):
             if shard.get('start') and min_start > _parse_datetime(
                     shard.get('start')):
                 min_start = _parse_datetime(shard.get('start'))
-            if shard.get('executionStatus') not in ['Failed', 'Done', 'Aborted']:
+            if shard.get('executionStatus') not in [
+                    'Failed', 'Done', 'Aborted'
+            ]:
                 max_end = None
             if max_end is not None and max_end < _parse_datetime(
                     shard.get('end')):

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -376,7 +376,7 @@ def format_scattered_task(task_name, task_metadata):
             if shard.get('start') and min_start > _parse_datetime(
                     shard.get('start')):
                 min_start = _parse_datetime(shard.get('start'))
-            if shard.get('executionStatus') not in ['Failed', 'Done']:
+            if shard.get('executionStatus') not in ['Failed', 'Done', 'Aborted']:
                 max_end = None
             if max_end is not None and max_end < _parse_datetime(
                     shard.get('end')):


### PR DESCRIPTION
The Cromwell shim layer was not setting the end time, so duration was incorrectly calculated within the UI.