### PR TITLE
Fix an issue that messes up subworkflows in specific Cromwells

### DIFF
--- a/cromwell-caas-compose.yml
+++ b/cromwell-caas-compose.yml
@@ -22,6 +22,7 @@ services:
       - CROMWELL_URL=${CROMWELL_URL:-https://cromwell.caas-dev.broadinstitute.org/api/workflows/v1}
       - SAM_URL=${SAM_URL}
       - USE_CAAS=True
+      - IS_CROMIAM=True
   jobs-proxy:
     extends:
       file: common-compose.yml

--- a/cromwell-caas-compose.yml
+++ b/cromwell-caas-compose.yml
@@ -22,7 +22,7 @@ services:
       - CROMWELL_URL=${CROMWELL_URL:-https://cromwell.caas-dev.broadinstitute.org/api/workflows/v1}
       - SAM_URL=${SAM_URL}
       - USE_CAAS=True
-      - IS_CROMIAM=True
+      - INCLUDE_SUBWORKFLOWS=True
   jobs-proxy:
     extends:
       file: common-compose.yml

--- a/servers/cromwell/README.md
+++ b/servers/cromwell/README.md
@@ -119,10 +119,10 @@ Thin shim around [`cromwell`](https://github.com/broadinstitute/cromwell).
         - If the field is `editable`, then `fieldType` is required.
         - If the field is `editable`, then `filterable` will be ignored.
 
-- (Required, CromIAM only) Configure fields to display
-  - **Note:** If you want to use Job Manager against CromIAM, which is using SAM/Google OAuth for authZ/authN:
+- (Optional) Configure fields to display
+  - **Note:** If you want to use Job Manager against Cromwell instances that are using Google OAuth for authZ/authN but NOT SAM (CromIAM):
 
-    1. you need to set the environment variable `IS_CROMIAM` to `True`, i.e. `export IS_CROMIAM=True` for the API, which speeds up the processing by omitting redundant subworkflows query in Cromwell. See details [here](https://github.com/DataBiosphere/job-manager/pull/576/files#diff-7c1402d297121c5f41a8bb4659a55271R391)
+    1. you need to set the environment variable `INCLUDE_SUBWORKFLOWS` to `False`, i.e. `export INCLUDE_SUBWORKFLOWS=False` for the API, so it can filter out sub-workflows in the job list page. See details [here](https://github.com/DataBiosphere/job-manager/pull/576/files#diff-7c1402d297121c5f41a8bb4659a55271R391)
     2. the `capabilities_config.json` must also include some extra fields, as well as proper scopes, which are shown as below:
 ```json
 {

--- a/servers/cromwell/README.md
+++ b/servers/cromwell/README.md
@@ -5,7 +5,7 @@ Thin shim around [`cromwell`](https://github.com/broadinstitute/cromwell).
 ## Development
 
 - Set the `CROMWELL_URL` environment variable to specify which cromwell instance to use, for example:
-    
+
     ```
     export CROMWELL_URL=https://example-cromwell.broadinstitute.org/api/workflows/v1
     ```
@@ -120,7 +120,10 @@ Thin shim around [`cromwell`](https://github.com/broadinstitute/cromwell).
         - If the field is `editable`, then `filterable` will be ignored.
 
 - (Required, CromIAM only) Configure fields to display
-  - **Note:** If you want to use Job Manager against CromIAM, which is using SAM/Google OAuth for authZ/authN, the `capabilities_config.json` must also include some extra fields, as well as proper scopes, which are shown as below:
+  - **Note:** If you want to use Job Manager against CromIAM, which is using SAM/Google OAuth for authZ/authN:
+
+    1. you need to set the environment variable `IS_CROMIAM` to `True`, i.e. `export IS_CROMIAM=True` for the API, which speeds up the processing by omitting redundant subworkflows query in Cromwell. See details [here](https://github.com/DataBiosphere/job-manager/pull/576/files#diff-7c1402d297121c5f41a8bb4659a55271R391)
+    2. the `capabilities_config.json` must also include some extra fields, as well as proper scopes, which are shown as below:
 ```json
 {
   "displayFields": [

--- a/servers/cromwell/jobs/__main__.py
+++ b/servers/cromwell/jobs/__main__.py
@@ -23,10 +23,11 @@ parser.add_argument('--cromwell_url',
                     type=str,
                     help='Url for fetching data from cromwell',
                     default=os.environ.get('CROMWELL_URL'))
-parser.add_argument('--include_subworkflows',
-                    type=bool,
-                    help='Whether to include subworkflows if the Cromwell is using OAuth',
-                    default=strtobool(os.getenv('INCLUDE_SUBWORKFLOWS', "True")))
+parser.add_argument(
+    '--include_subworkflows',
+    type=bool,
+    help='Whether to include subworkflows if the Cromwell is using OAuth',
+    default=strtobool(os.getenv('INCLUDE_SUBWORKFLOWS', "True")))
 parser.add_argument('--sam_url',
                     type=str,
                     help='Url for fetching authentication from SAM',

--- a/servers/cromwell/jobs/__main__.py
+++ b/servers/cromwell/jobs/__main__.py
@@ -9,6 +9,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import logging
 from .models.capabilities_response import CapabilitiesResponse
+from distutils.util import strtobool
 
 CROMWELL_LABEL_MIN_LENGTH = 1
 CROMWELL_LABEL_MAX_LENGTH = 256
@@ -22,10 +23,10 @@ parser.add_argument('--cromwell_url',
                     type=str,
                     help='Url for fetching data from cromwell',
                     default=os.environ.get('CROMWELL_URL'))
-parser.add_argument('--is_cromiam',
+parser.add_argument('--include_subworkflows',
                     type=bool,
-                    help='Whether if the cromwell backend is CromIAM',
-                    default=os.environ.get('IS_CROMIAM', False))
+                    help='Whether to include subworkflows if the Cromwell is using OAuth',
+                    default=strtobool(os.getenv('INCLUDE_SUBWORKFLOWS', "True")))
 parser.add_argument('--sam_url',
                     type=str,
                     help='Url for fetching authentication from SAM',
@@ -93,7 +94,7 @@ except (IOError, TypeError):
 app.app.config['cromwell_url'] = args.cromwell_url
 app.app.config['sam_url'] = args.sam_url
 app.app.config['use_caas'] = args.use_caas and args.use_caas.lower() == 'true'
-app.app.config['is_cromiam'] = args.is_cromiam
+app.app.config['include_subworkflows'] = args.include_subworkflows
 app.app.json_encoder = JSONEncoder
 app.add_api('swagger.yaml', base_path=args.path_prefix)
 

--- a/servers/cromwell/jobs/__main__.py
+++ b/servers/cromwell/jobs/__main__.py
@@ -22,6 +22,10 @@ parser.add_argument('--cromwell_url',
                     type=str,
                     help='Url for fetching data from cromwell',
                     default=os.environ.get('CROMWELL_URL'))
+parser.add_argument('--is_cromiam',
+                    type=bool,
+                    help='Whether if the cromwell backend is CromIAM',
+                    default=os.environ.get('IS_CROMIAM', False))
 parser.add_argument('--sam_url',
                     type=str,
                     help='Url for fetching authentication from SAM',
@@ -89,6 +93,7 @@ except (IOError, TypeError):
 app.app.config['cromwell_url'] = args.cromwell_url
 app.app.config['sam_url'] = args.sam_url
 app.app.config['use_caas'] = args.use_caas and args.use_caas.lower() == 'true'
+app.app.config['is_cromiam'] = args.is_cromiam
 app.app.json_encoder = JSONEncoder
 app.add_api('swagger.yaml', base_path=args.path_prefix)
 

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -519,7 +519,7 @@ def cromwell_query_params(query, page, page_size, has_auth):
     # is sending requests to a CromIAM, not a Cromwell.  CromIAM can't retrieve
     # subworkflows, so it's not necessary to the query (and slows things down
     # significantly)
-    if not has_auth or not _is_iam():
+    if not has_auth or not _include_subworkflows():
         query_params.append({'includeSubworkflows': 'false'})
     if query.extensions and query.extensions.hide_archived:
         query_params.append({'excludeLabelAnd': 'flag:archive'})
@@ -684,8 +684,8 @@ def _get_sam_url():
     return current_app.config['sam_url']
 
 
-def _is_iam():
-    return current_app.config['is_cromiam']
+def _include_subworkflows():
+    return current_app.config['include_subworkflows']
 
 
 def _format_query_labels(orig_query_labels):

--- a/servers/cromwell/jobs/controllers/jobs_controller.py
+++ b/servers/cromwell/jobs/controllers/jobs_controller.py
@@ -519,7 +519,7 @@ def cromwell_query_params(query, page, page_size, has_auth):
     # is sending requests to a CromIAM, not a Cromwell.  CromIAM can't retrieve
     # subworkflows, so it's not necessary to the query (and slows things down
     # significantly)
-    if not has_auth:
+    if not has_auth or not _is_iam():
         query_params.append({'includeSubworkflows': 'false'})
     if query.extensions and query.extensions.hide_archived:
         query_params.append({'excludeLabelAnd': 'flag:archive'})
@@ -682,6 +682,10 @@ def _get_base_url():
 
 def _get_sam_url():
     return current_app.config['sam_url']
+
+
+def _is_iam():
+    return current_app.config['is_cromiam']
 
 
 def _format_query_labels(orig_query_labels):

--- a/servers/cromwell/jobs/test/test_auth_utils.py
+++ b/servers/cromwell/jobs/test/test_auth_utils.py
@@ -16,7 +16,8 @@ class TestAuthUtils(BaseTestCase):
             'cromwell_user': '',
             'cromwell_password': '',
             'use_caas': True,
-            'capabilities': {}
+            'capabilities': {},
+            'is_cromiam': False
         })
 
         def _request_callback(request, context):

--- a/servers/cromwell/jobs/test/test_auth_utils.py
+++ b/servers/cromwell/jobs/test/test_auth_utils.py
@@ -17,7 +17,7 @@ class TestAuthUtils(BaseTestCase):
             'cromwell_password': '',
             'use_caas': True,
             'capabilities': {},
-            'is_cromiam': False
+            'include_subworkflows': True
         })
 
         def _request_callback(request, context):


### PR DESCRIPTION
## Reason

In general, we are deploying JMUI against a Cromwell instance that uses OAuth (an OIDC based AuthProxy) but does not have CromIAM. This is affected by https://github.com/DataBiosphere/job-manager/pull/576 that subworkflows are showing up in the job details page.

See discussion here: https://broadinstitute.slack.com/archives/CFA6Q2QBU/p1599146973203800?thread_ts=1599145468.201200&cid=CFA6Q2QBU

## Changes

Add a `INCLUDE_SUBWORKFLOWS` flag and set it to `True` by default so subworkflows are filtered out by default as well. non-CromIAM Cromwell backends that are using OAuth should set it to `False`.