### PR TITLE
Add AppSec GitHub Trivy Action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,21 @@
+name: dsp-appsec-trivy
+on: [pull_request]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workdir:
+        - servers/cromwell
+        - servers/dsub
+        - ui
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: broadinstitute/dsp-appsec-trivy-action@v1
+        working-directory: ${{ matrix.workdir }}


### PR DESCRIPTION
This change adds Trivy security scan for the Docker image, as discussed in the Workbench Cross-Team meeting.

The action will run on every PR and give you feedback if the Docker image contains critical OS vulnerabilities.

More info:
https://github.com/broadinstitute/dsp-appsec-trivy-action
https://github.com/broadinstitute/dsp-appsec-blessed-images