### PR TITLE
[BT-85] [BT-78] Add AppSec GitHub Trivy Action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,4 +18,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
-        working-directory: ${{ matrix.workdir }}
+        with:
+          dockerfile: ${{ matrix.workdir }}/Dockerfile
+          context: ${{ matrix.workdir }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,21 @@
+name: dsp-appsec-trivy
+on: [pull_request]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workdir:
+        - servers/cromwell
+        - servers/dsub
+        - ui
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: broadinstitute/dsp-appsec-trivy-action@v1
+        working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,4 +19,4 @@ jobs:
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
-          context: ${{ matrix.workdir }}
+          dockerfile: ./${{ matrix.workdir }}/Dockerfile

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,5 +19,4 @@ jobs:
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
-          dockerfile: ${{ matrix.workdir }}/Dockerfile
           context: ${{ matrix.workdir }}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -21,7 +21,7 @@ RUN npm install
 
 RUN /ui/node_modules/.bin/ng build --prod
 
-FROM nginx:1.19.0
+FROM nginx:1.19.6
 
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
This change adds Trivy security scan for the Docker image, as discussed in the Workbench Cross-Team meeting.

The action will run on every PR and give you feedback if the Docker image contains critical OS vulnerabilities.

More info:
https://github.com/broadinstitute/dsp-appsec-trivy-action
https://github.com/broadinstitute/dsp-appsec-blessed-images