### PR TITLE
Resolve all Job Manager HIGHs & update docs [BW-752]

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,31 +165,31 @@ For `cromwell` server documentation, see [servers/cromwell](servers/cromwell/REA
 
 ### How to build
 
-From v0.2.0, Job Manager starts to release stock docker images on [DockerHub](https://hub.docker.com/u/databiosphere)
+Starting with release v1.6.0, Job Manager docker images are on [GCR](https://console.cloud.google.com/gcr/images/broad-dsp-gcr-public).
 
-- Setting the docker tag first in bash, e.g. `TAG="v0.1.0"`
-
-- To build the `job-manager-ui` image with `$TAG` from the root of this Github repository:
+- Configure Docker to authenticate with GCR
     ```
-    docker build -t job-manager-ui:$TAG . -f ui/Dockerfile
+    gcloud config set account username@broadinstitute.org
+    gcloud auth configure-docker us.gcr.io
+    ```
+
+- Set the Docker tag first in bash, e.g. `TAG="v0.1.0"`
+
+- To publish the `job-manager-ui` image with `$TAG` from the root of this Github repository:
+    ```
+    docker build -t us.gcr.io/broad-dsp-gcr-public/job-manager-ui:$TAG . -f ui/Dockerfile
+    docker push us.gcr.io/broad-dsp-gcr-public/job-manager-ui:$TAG
     ```
     
-- **Cromwell:** To build the `job-manager-api-cromwell` image with `$TAG` from the root of this Github repository:
+- To publish the `job-manager-api-cromwell` image with `$TAG` from the root of this Github repository:
     ```
-    docker build -t job-manager-api-cromwell:$TAG . -f servers/cromwell/Dockerfile
-    ```
-    
-- **dsub:** To build the `job-manager-api-dsub` image with `$TAG` from the root of this Github repository:
-    ```
-    docker build -t job-manager-api-dsub:$TAG . -f servers/dsub/Dockerfile
+    docker build -t us.gcr.io/broad-dsp-gcr-public/job-manager-api-cromwell:$TAG . -f servers/cromwell/Dockerfile
+    docker push us.gcr.io/broad-dsp-gcr-public/job-manager-api-cromwell:$TAG
     ```
 
-### Add a github release pointing to the dockerhub images
+### Add a Github release pointing to the GCR images
 
-From v0.2.0, each release in Github will also release 3 corresponding docker images on Docker Hub:
+From v1.6.0, each release in Github will also release 2 corresponding Docker images on GCR:
 
-- [job-manager-ui](https://hub.docker.com/r/databiosphere/job-manager-ui/)
-- [job-manager-api-cromwell](https://hub.docker.com/r/databiosphere/job-manager-api-cromwell/)
-- [job-manager-api-dsub](https://hub.docker.com/r/databiosphere/job-manager-api-dsub/)
-
-For a long-term plan, we will set up a docker build hook so the release process can be more automated.
+- [job-manager-ui](https://console.cloud.google.com/gcr/images/broad-dsp-gcr-public/US/job-manager-ui)
+- [job-manager-api-cromwell](https://console.cloud.google.com/gcr/images/broad-dsp-gcr-public/US/job-manager-api-cromwell)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 [![Github](https://img.shields.io/badge/Docker%20Image-dsub%20shim%20API-blue.svg?style=flat-square)](https://cloud.docker.com/u/databiosphere/repository/docker/databiosphere/job-manager-api-dsub)
 [![Github](https://img.shields.io/badge/Docker%20Image-cromwell%20shim%20API-blue.svg?style=flat-square)](https://cloud.docker.com/u/databiosphere/repository/docker/databiosphere/job-manager-api-cromwell)
 
+## Lifecycle notice
+
+Job Manager is in maintenance mode and is not recommended for new projects.
+
+dsub support is deprecated and will be removed in a future release.
+
+The last release of Job Manager to support dsub without compromise is [1.5.7](https://github.com/DataBiosphere/job-manager/releases/tag/v1.5.7).
+
 ## User facing documentation
 
 Welcome to the Job Manager repository! If you're a developer you're in the right place.
@@ -15,10 +23,6 @@ Welcome to the Job Manager repository! If you're a developer you're in the right
 However, if you just want to try out or deploy Job Manager, you will probably find our user and deployment focused content in
 our ReadTheDocs pages: https://data-biosphere-job-manager.readthedocs.io/en/latest/
 
-### Try it out, NOW!
-
-The easiest way to try out Job Manager is to use the [getting started script](https://data-biosphere-job-manager.readthedocs.io/en/stable/GettingStarted/QuickStart)
- 
 ## Welcome
 
 See the [development guide](#development) below.
@@ -35,20 +39,6 @@ The Job Manager aspires to bring ease and efficiency to developing and debugging
 * Rich search capabilities across current and historic workflows
 * Aborting workflows
 * Clean, intuitive UX based on material design principles
-
-### Future Features
-* Dynamic grouping, filtering, and drill-down
-* Re-launching workflows
-* Simplified troubleshooting of failed workflows
-* Improved UI design
-
-## Roadmap
-
-The current code is a work in progress towards an alpha release and as such has started with core features: connecting to both backends, visualizing workflow and task status and metadata, quick access to log files, and simple filtering.
-
-The near-term roadmap includes improvements to failure troubleshooting, creating a robust dashboard for grouping jobs and seeing status overviews, and improving handling of widely scattered workflows.
-
-We envision a product with user-customizable views of jobs running, insights into workflow compute cost, the ability to re-launch jobs, and the potential to make custom reports about the jobs that have been run.
 
 ## Architecture Overview
 

--- a/servers/cromwell/Dockerfile
+++ b/servers/cromwell/Dockerfile
@@ -6,7 +6,7 @@ ADD ./ /job-manager
 
 RUN /bin/bash -c scripts/rebuild_swagger.sh
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian
+FROM gcr.io/google-appengine/python
 
 WORKDIR /app
 

--- a/servers/cromwell/Dockerfile
+++ b/servers/cromwell/Dockerfile
@@ -6,7 +6,7 @@ ADD ./ /job-manager
 
 RUN /bin/bash -c scripts/rebuild_swagger.sh
 
-FROM gcr.io/google-appengine/python
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian
 
 WORKDIR /app
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -21,7 +21,7 @@ RUN npm install
 
 RUN /ui/node_modules/.bin/ng build --prod
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-debian
+FROM nginx:mainline-alpine
 
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,7 +6,7 @@ ADD ./ /job-manager
 
 RUN /bin/bash -c scripts/rebuild_swagger.sh
 
-FROM node:lts
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:14-debian
 
 WORKDIR /ui
 
@@ -21,7 +21,7 @@ RUN npm install
 
 RUN /ui/node_modules/.bin/ng build --prod
 
-FROM nginx:stable
+FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-debian
 
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -21,7 +21,7 @@ RUN npm install
 
 RUN /ui/node_modules/.bin/ng build --prod
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-debian
+FROM nginx:stable
 
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,7 +6,7 @@ ADD ./ /job-manager
 
 RUN /bin/bash -c scripts/rebuild_swagger.sh
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:14-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:12-debian
 
 WORKDIR /ui
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -21,7 +21,7 @@ RUN npm install
 
 RUN /ui/node_modules/.bin/ng build --prod
 
-FROM nginx:stable
+FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:mainline-debian
 
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -23,7 +23,5 @@ RUN /ui/node_modules/.bin/ng build --prod
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-debian
 
-USER nginx
-
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -21,7 +21,9 @@ RUN npm install
 
 RUN /ui/node_modules/.bin/ng build --prod
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:mainline-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-debian
+
+USER nginx
 
 COPY --from=1 /ui/dist /ui/dist
 ADD ./ui/nginx.prod.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
```
docker run -it aquasec/trivy:latest image --ignore-unfixed --vuln-type os us.gcr.io/broad-dsp-gcr-public/job-manager-ui:v1.6.0_rc5
2021-07-29T18:09:17.611Z	INFO	Need to update DB
2021-07-29T18:09:17.611Z	INFO	Downloading DB...
22.65 MiB / 22.65 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20.87 MiB p/s 2s
2021-07-29T18:09:20.454Z	INFO	Detected OS: alpine
2021-07-29T18:09:20.454Z	INFO	Detecting Alpine vulnerabilities...

us.gcr.io/broad-dsp-gcr-public/job-manager-ui:v1.6.0_rc5 (alpine 3.14.0)
========================================================================
Total: 9 (UNKNOWN: 1, LOW: 4, MEDIUM: 4, HIGH: 0, CRITICAL: 0)
```
```
docker run -it aquasec/trivy:latest image --ignore-unfixed --vuln-type os us.gcr.io/broad-dsp-gcr-public/job-manager-api-cromwell:v1.6.0_rc1
2021-07-29T18:10:04.811Z	INFO	Need to update DB
2021-07-29T18:10:04.811Z	INFO	Downloading DB...
22.65 MiB / 22.65 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24.21 MiB p/s 1s
2021-07-29T18:10:26.002Z	INFO	Detected OS: ubuntu
2021-07-29T18:10:26.002Z	INFO	Detecting Ubuntu vulnerabilities...

us.gcr.io/broad-dsp-gcr-public/job-manager-api-cromwell:v1.6.0_rc1 (ubuntu 16.04)
=================================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```