### PR TITLE
BT-628 Upgrade node to 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,6 @@ jobs:
             export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             
-            # The CI code that ran on the previous "latest" Circle machine image used the nvm included on that image
-            # to install what that version of nvm considered to be the LTS version of Node. However the current Node LTS
-            # is now 16 and some of JMUI's dependencies break with Node 14+, so install Node 12 explicitly.
-            #
-            # npm WARN deprecated chokidar@1.7.0: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
             nvm install 14
             
             cd ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,12 @@ jobs:
             # is now 16 and some of JMUI's dependencies break with Node 14+, so install Node 12 explicitly.
             #
             # npm WARN deprecated chokidar@1.7.0: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
-            nvm install 12
+            nvm install 14
             
             cd ui
             npm install
             
-            # node-sass was apparently built for Node 6 and requires this extra step for Node 12.
+            # node-sass was apparently built for Node 6 and requires this extra step for Node 14.
             npm rebuild node-sass
             
             npm install -g @angular/cli@1.7.4
@@ -79,7 +79,7 @@ jobs:
             # nvm setup commands and Node install reprised
             export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-            nvm install 12
+            nvm install 14
             ng lint --type-check
       - run:
           name: Run UI unit tests
@@ -88,7 +88,7 @@ jobs:
             # nvm setup commands and Node install reprised
             export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-            nvm install 12
+            nvm install 14
             ng test --single-run -sm=false --browsers=ChromeHeadless
       - run:
           name: Ensure the UI builds for prod
@@ -100,7 +100,7 @@ jobs:
             # nvm setup commands and Node install reprised
             export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-            nvm install 12
+            nvm install 14
             ng build --target=production --environment=dev
 
   backends:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,7 +6,7 @@ ADD ./ /job-manager
 
 RUN /bin/bash -c scripts/rebuild_swagger.sh
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:12-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:14-debian
 
 WORKDIR /ui
 

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -1,5 +1,7 @@
 # Note: This is the dockerfile for development purposes
 
+# We are aware that some dev dependencies are broken in node 14, for example chokidar
+# npm WARN deprecated chokidar@1.7.0: Chokidar 2 will break on node v14+. 
 FROM node:14
 
 # Install python 2, needed for npm packages

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Note: This is the dockerfile for development purposes
 
-FROM node:14 
+FROM node:14
 
 # Install python 2, needed for npm packages
 RUN apt-get update && apt-get -y install python

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Note: This is the dockerfile for development purposes
 
-FROM node:14
+FROM node:14 
 
 # Install python 2, needed for npm packages
 RUN apt-get update && apt-get -y install python


### PR DESCRIPTION
Narrow upgrade of node 12 -> 14 because node 12 is EOL. Note that the dev docker file already specified node 14, so it is not included in these changes.

I ran the app locally and clicked around everything I could find, and it all seemed to work normally.