### PR TITLE
[BT-720] Update `extend`

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3825,9 +3825,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "optional": true
     },

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4368,12 +4368,6 @@
             "jsbn": "~0.1.0"
           }
         },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,


### PR DESCRIPTION
Update usage of the `extend` library to at least `3.0.2`.

After initially believing that this was actually a prod dependency, further investigation makes me unsure now. The closest links I could find were through `request:2.81.0`, but that traces back to `chokidar` (a file watcher for running development mode, via `fsevents:1.1.3` -> `node-pre-gyp:0.6.39`) and `less:2.7.3` (via `@angular/cli:1.6.5`).

However, since I believe I've already done the work to update this, I'd like to push it through. I think there's still value to be gained in confirming that this will clear the SourceClear warning.