### PR TITLE
Pin typescript version to 4.8.4

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     "protractor": "^7.0.0",
     "sshpk": "^1.17.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.2"
+    "typescript": "~4.8.2"
   },
   "packageManager": "yarn@3.2.2"
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6326,7 +6326,7 @@ __metadata:
     sass: ^1.54.9
     sshpk: ^1.17.0
     ts-node: ^10.9.1
-    typescript: ^4.8.2
+    typescript: 4.8.4
     zone.js: ^0.11.8
   languageName: unknown
   linkType: soft

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6326,7 +6326,7 @@ __metadata:
     sass: ^1.54.9
     sshpk: ^1.17.0
     ts-node: ^10.9.1
-    typescript: 4.8.4
+    typescript: ~4.8.2
     zone.js: ^0.11.8
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Both the latest Angular versions 14 & 15 requires a version of TypeScript that is 4.8.x and not the latest (At the time of writing 4.9.3). This elects to pin the version for Job Manager to ~4.8.2 which will default to 4.8.4 until other patch versions are released. 