### PR TITLE
WX-1019 Security patches

### DIFF
--- a/servers/cromwell/requirements.txt
+++ b/servers/cromwell/requirements.txt
@@ -3,7 +3,7 @@ chardet==3.0.4
 click==8.1.3
 clickclick==1.2.2
 connexion==2.14.1
-Flask==2.2.2
+Flask==2.2.5
 gevent==21.12.0
 greenlet==1.1.3
 gunicorn==20.1.0

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,7 +35,7 @@
     "zone.js": "^0.11.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^14.2.10",
+    "@angular-devkit/build-angular": "^14.2.11",
     "@angular-eslint/schematics": "^14.0.3",
     "@angular/cli": "^14.2.1",
     "@angular/compiler-cli": "^14.2.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -32,24 +32,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.1402.10":
-  version: 0.1402.10
-  resolution: "@angular-devkit/architect@npm:0.1402.10"
+"@angular-devkit/architect@npm:0.1402.11":
+  version: 0.1402.11
+  resolution: "@angular-devkit/architect@npm:0.1402.11"
   dependencies:
-    "@angular-devkit/core": 14.2.10
+    "@angular-devkit/core": 14.2.11
     rxjs: 6.6.7
-  checksum: 668aa04962f1e58624b053882dfd2064476a7dbf34950eeb08e8fa3e85ee778f860a4a03cf154dbe6447ec3fda154b2e6b14d0174860e6865002c4d48b1c4be2
+  checksum: c494678e47aa80662acdd5b1d68ecae892add773cca4690f0e43b344fbce3d4414d9f50fc642906b3ad4c89a6067b2c6672154114ed4f9e9b3d1d99f5f8e71ed
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-angular@npm:^14.2.10":
-  version: 14.2.10
-  resolution: "@angular-devkit/build-angular@npm:14.2.10"
+"@angular-devkit/build-angular@npm:^14.2.11":
+  version: 14.2.11
+  resolution: "@angular-devkit/build-angular@npm:14.2.11"
   dependencies:
     "@ampproject/remapping": 2.2.0
-    "@angular-devkit/architect": 0.1402.10
-    "@angular-devkit/build-webpack": 0.1402.10
-    "@angular-devkit/core": 14.2.10
+    "@angular-devkit/architect": 0.1402.11
+    "@angular-devkit/build-webpack": 0.1402.11
+    "@angular-devkit/core": 14.2.11
     "@babel/core": 7.18.10
     "@babel/generator": 7.18.12
     "@babel/helper-annotate-as-pure": 7.18.6
@@ -60,7 +60,7 @@ __metadata:
     "@babel/runtime": 7.18.9
     "@babel/template": 7.18.10
     "@discoveryjs/json-ext": 0.5.7
-    "@ngtools/webpack": 14.2.10
+    "@ngtools/webpack": 14.2.11
     ansi-colors: 4.1.3
     babel-loader: 8.2.5
     babel-plugin-istanbul: 6.1.1
@@ -104,7 +104,7 @@ __metadata:
     text-table: 0.2.0
     tree-kill: 1.2.2
     tslib: 2.4.0
-    webpack: 5.74.0
+    webpack: 5.76.1
     webpack-dev-middleware: 5.3.3
     webpack-dev-server: 4.11.0
     webpack-merge: 5.8.0
@@ -134,20 +134,20 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 0fb0b3edc15602465826ecf324faacbae8e18d526ec21caee479398cc52241e006447455df432e79ecce6e89c69f53477d002cefb481a56ea47958a9313ada17
+  checksum: b420ae49d561bf8c21203abc1eed2a9078cc3dd6ccbf6d18ab2662a31c6a84dd14a084b614cf18033fe0ca7bfb31ccad2e2e9b9595ee37f9c7435cfe6c36ab31
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-webpack@npm:0.1402.10":
-  version: 0.1402.10
-  resolution: "@angular-devkit/build-webpack@npm:0.1402.10"
+"@angular-devkit/build-webpack@npm:0.1402.11":
+  version: 0.1402.11
+  resolution: "@angular-devkit/build-webpack@npm:0.1402.11"
   dependencies:
-    "@angular-devkit/architect": 0.1402.10
+    "@angular-devkit/architect": 0.1402.11
     rxjs: 6.6.7
   peerDependencies:
     webpack: ^5.30.0
     webpack-dev-server: ^4.0.0
-  checksum: 16564303923316c82771d0b987b4c0fd88cb09cee214943bce0ec9ee5ed2e12e58ef3ca50be16b6eff1d5c850c37ac246d5e0cc58da658a87daf062e23e33cec
+  checksum: 4619dfb2f958a9150b2e43e8d1a1e5e8905f3e8db5b8c8bc82e5c0cdbf4ce7ead35add634773fcb775a205c7d4469246b3b7d08dba0a346724c3482d9e1087e5
   languageName: node
   linkType: hard
 
@@ -169,9 +169,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:14.2.10":
-  version: 14.2.10
-  resolution: "@angular-devkit/core@npm:14.2.10"
+"@angular-devkit/core@npm:14.2.11":
+  version: 14.2.11
+  resolution: "@angular-devkit/core@npm:14.2.11"
   dependencies:
     ajv: 8.11.0
     ajv-formats: 2.1.1
@@ -183,7 +183,7 @@ __metadata:
   peerDependenciesMeta:
     chokidar:
       optional: true
-  checksum: 61c037d3228448ad388997e55080f6791bdb9afb4d323e5b17d94947f4a0dbb0b982908c74d2ad827728174b17ac781881ea946795739860c9bac576f2c379f0
+  checksum: 5672fe0f44b557e637d97a12c1aea9c23b154005430dda4e5c80e0f0f73ff465e115e726d398f2d9008b2cf81c152083402ac234f1454a76db3f748c057a1c72
   languageName: node
   linkType: hard
 
@@ -2191,14 +2191,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ngtools/webpack@npm:14.2.10":
-  version: 14.2.10
-  resolution: "@ngtools/webpack@npm:14.2.10"
+"@ngtools/webpack@npm:14.2.11":
+  version: 14.2.11
+  resolution: "@ngtools/webpack@npm:14.2.11"
   peerDependencies:
     "@angular/compiler-cli": ^14.0.0
     typescript: ">=4.6.2 <4.9"
     webpack: ^5.54.0
-  checksum: 84b4d0d4dc4ad3b614982564ff7e57ad5c4a86582a8688dd047bb8e9b5303d6076a8ffd8d2a284713377c4358775d98d5893b00fe4a31b7d62fd1907ef95ffb0
+  checksum: 84c5b078a1e0327907acaf49075913347d6686dd07388eeaf63782e79615a2517758de60371a4c2410e26e1eb9ceb543c07f4c5f1a132bb13e25404e10e1d757
   languageName: node
   linkType: hard
 
@@ -6453,7 +6453,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "job-manager-ui@workspace:."
   dependencies:
-    "@angular-devkit/build-angular": ^14.2.10
+    "@angular-devkit/build-angular": ^14.2.11
     "@angular-eslint/schematics": ^14.0.3
     "@angular/animations": ^14.2.0
     "@angular/cdk": ^14.2.0
@@ -10470,9 +10470,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.74.0":
-  version: 5.74.0
-  resolution: "webpack@npm:5.74.0"
+"webpack@npm:5.76.1":
+  version: 5.76.1
+  resolution: "webpack@npm:5.76.1"
   dependencies:
     "@types/eslint-scope": ^3.7.3
     "@types/estree": ^0.0.51
@@ -10503,7 +10503,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 320c41369a75051b19e18c63f408b3dcc481852e992f83d311771c5ec0f05f2946385e8ebef62030cf3587f0a3d2f12779ffdb191569a966847289ba7313f946
+  checksum: b01fe0bc2dbca0e10d290ddb0bf81e807a031de48028176e2b21afd696b4d3f25ab9accdad888ef4a1f7c7f4d41f13d5bf2395b7653fdf3e5e3dafa54e56dab2
   languageName: node
   linkType: hard
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4605,9 +4605,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"engine.io@npm:~6.2.0":
-  version: 6.2.1
-  resolution: "engine.io@npm:6.2.1"
+"engine.io@npm:~6.4.1":
+  version: 6.4.2
+  resolution: "engine.io@npm:6.4.2"
   dependencies:
     "@types/cookie": ^0.4.1
     "@types/cors": ^2.8.12
@@ -4618,8 +4618,8 @@ __metadata:
     cors: ~2.8.5
     debug: ~4.3.1
     engine.io-parser: ~5.0.3
-    ws: ~8.2.3
-  checksum: 626d7a77f2f6d3e1f888c43932e2f34222201b6c0bc4bcbb0ead054cc170a1df3bf0d6f8b34432e68d7223346b7aa5ed34fbda1e706ef02b7801789465e34f40
+    ws: ~8.11.0
+  checksum: c4ca538c98d251ff00756ed955d924c3fd78e61af0a5825c9fa1d77ebb661ead7971598fb61daf079c2655c7be2d4a26094e446759e3c6786d8ac75ccffe36d5
   languageName: node
   linkType: hard
 
@@ -9417,34 +9417,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socket.io-adapter@npm:~2.4.0":
-  version: 2.4.0
-  resolution: "socket.io-adapter@npm:2.4.0"
-  checksum: a84639946dce13547b95f6e09fe167cdcd5d80941afc2e46790cc23384e0fd3c901e690ecc9bdd600939ce6292261ee15094a0b486f797ed621cfc8783d87a0c
+"socket.io-adapter@npm:~2.5.2":
+  version: 2.5.2
+  resolution: "socket.io-adapter@npm:2.5.2"
+  dependencies:
+    ws: ~8.11.0
+  checksum: 481251c3547221e57eb5cb247d0b1a3cde4d152a4c1c9051cc887345a7770e59f3b47f1011cac4499e833f01fcfc301ed13c4ec6e72f7dbb48a476375a6344cd
   languageName: node
   linkType: hard
 
-"socket.io-parser@npm:~4.2.0":
-  version: 4.2.1
-  resolution: "socket.io-parser@npm:4.2.1"
+"socket.io-parser@npm:~4.2.1":
+  version: 4.2.2
+  resolution: "socket.io-parser@npm:4.2.2"
   dependencies:
     "@socket.io/component-emitter": ~3.1.0
     debug: ~4.3.1
-  checksum: 2582202f22538d7e6b4436991378cb4cea3b2f8219cda24923ae35afd291ab5ad6120e7d093e41738256b6c6ad10c667dd25753c2d9a2340fead04e9286f152d
+  checksum: ba929645cb252e23d9800f00c77092480d07cc5d6c97a5d11f515ef636870ea5b3ad6f62b7ba6147b4d703efc92588064f5638a0a0841c8530e4ac50c4b1197a
   languageName: node
   linkType: hard
 
 "socket.io@npm:^4.4.1":
-  version: 4.5.2
-  resolution: "socket.io@npm:4.5.2"
+  version: 4.6.1
+  resolution: "socket.io@npm:4.6.1"
   dependencies:
     accepts: ~1.3.4
     base64id: ~2.0.0
     debug: ~4.3.2
-    engine.io: ~6.2.0
-    socket.io-adapter: ~2.4.0
-    socket.io-parser: ~4.2.0
-  checksum: 8527dd78fa3cf483a2cf0f09f64c4591186931b6765e5d8456dd3022b8786407952e3b931a83a86513c9f56852442e12f3497c761a113113e32b0c867c5ad5a7
+    engine.io: ~6.4.1
+    socket.io-adapter: ~2.5.2
+    socket.io-parser: ~4.2.1
+  checksum: 447941727142669b3709c3ae59ed790a2c3ad312d935400e2e25fdf59a95cdc92ebcf6b000ab2042a2a77ae51bb87598b40845a8d3b1f6ea6a0dd1df9c8f8459
   languageName: node
   linkType: hard
 
@@ -10621,9 +10623,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:~8.2.3":
-  version: 8.2.3
-  resolution: "ws@npm:8.2.3"
+"ws@npm:~8.11.0":
+  version: 8.11.0
+  resolution: "ws@npm:8.11.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -10632,7 +10634,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: c869296ccb45f218ac6d32f8f614cd85b50a21fd434caf11646008eef92173be53490810c5c23aea31bc527902261fbfd7b062197eea341b26128d4be56a85e4
+  checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Three separate operations here:
 * Upgrade Flask on server side
 * Upgrade to next `angular-devkit/build-angular` patch in order to get `webpack >= 5.76.0`
 * Upgrade transitive dependency `socket.io` to get `engine.io >= 6.4.2`