### PR TITLE
WX-1192 Updated semver versions for flagged dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -63,5 +63,9 @@
     "ts-node": "^10.9.1",
     "typescript": "~4.8.2"
   },
+  "resolutions": {
+    "node-gyp/semver@^7.3.5": "7.5.2",
+    "@npmcli/fs/semver@^7.3.5": "7.5.2"
+  },
   "packageManager": "yarn@3.2.2"
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9250,6 +9250,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:7.5.2":
+  version: 7.5.2
+  resolution: "semver@npm:7.5.2"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 3fdf5d1e6f170fe8bcc41669e31787649af91af7f54f05c71d0865bb7aa27e8b92f68b3e6b582483e2c1c648008bc84249d2cd86301771fe5cbf7621d1fe5375
+  languageName: node
+  linkType: hard
+
 "semver@npm:^5.3.0, semver@npm:^5.6.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"


### PR DESCRIPTION
Addresses [WX-1192](https://broadworkbench.atlassian.net/browse/WX-1192)

PR updates the `semver` dependency in `sass` to `7.5.2` in order to patch out a CVE present in older versions.