### PR TITLE
WX-1305 Upgrade `gevent` to 23.9

### DIFF
--- a/servers/cromwell/requirements-to-freeze.txt
+++ b/servers/cromwell/requirements-to-freeze.txt
@@ -2,6 +2,6 @@ connexion == 1.1.13
 python_dateutil == 2.6.0
 typing == 3.5.2.2
 setuptools >= 65.4.1
-gevent==1.3.4
+gevent==23.9
 gunicorn==19.8.1
 ../jm_utils

--- a/servers/cromwell/requirements.txt
+++ b/servers/cromwell/requirements.txt
@@ -4,8 +4,8 @@ click==8.1.3
 clickclick==1.2.2
 connexion==2.14.1
 Flask==2.2.5
-gevent==21.12.0
-greenlet==1.1.3
+gevent==23.9
+greenlet==2.0.2
 gunicorn==20.1.0
 idna==2.7
 inflection==0.3.1


### PR DESCRIPTION
I edited `requirements.txt` and ran
```
pip install -r requirements.txt
```

Then I built a new container
```
docker build -t us.gcr.io/broad-dsp-gcr-public/job-manager-api-cromwell:v1.7.3-a1 . -f servers/cromwell/Dockerfile
```
and entered it
```
docker run -it --entrypoint /bin/bash us.gcr.io/broad-dsp-gcr-public/job-manager-api-cromwell:v1.7.3-a1
```
to verify the new library took effect, which it did:
```
# pip show gevent
Name: gevent
Version: 23.9.0
Summary: Coroutine-based network library
Home-page: http://www.gevent.org/
Author: Denis Bilenko
Author-email: denis.bilenko@gmail.com
License: MIT
Location: /usr/local/lib/python3.10/site-packages
Requires: greenlet, zope.event, zope.interface
Required-by: 
```