### PR TITLE
Move abort button

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Monitors jobs launched by the [Cromwell workflow engine](https://github.com/broa
 
 
 ### Run Locally
-- Run `docker-compose up` from the root of the repository:
+- Run `docker compose up` from the root of the repository:
   - If this is the first time running `docker-compose up`  this might take a few minutes.
   - Eventually you should see a compilation success message like this: 
   ```
@@ -107,11 +107,11 @@ Monitors jobs launched by the [Cromwell workflow engine](https://github.com/broa
 https://github.com/angular/angular-cli/issues/6349).
 2. Changes to `package.json`, `requirements.txt`, or `constraints.txt` [regenerating the API](#updating-the-api-using-swagger-codegen) require a rebuild with:
   ```
-  docker-compose up --build
+  docker compose up --build
   ```
   Alternatively, rebuild a single component:
   ```
-  docker-compose build ui
+  docker compose build jmui
   ```
 3. As of 03/31/2023 you'll need to register a `redirectURI` for your application if you've enabled Google OAuth for your JM instance. This is a result of Google deprecating the `Google Sign-In JavaScript Platform Library`.
   * To do so, log in to Google Cloud Platform and go to the `Credentials` page under the `API & Services` section of the sidebar.
@@ -128,7 +128,7 @@ https://github.com/angular/angular-cli/issues/6349).
 defined in `api/jobs.yaml` into appropriate classes for the servers and the UI to use.
 * Whenever the API is updated, run this to trigger a rebuild: 
 ```sh
-docker-compose up rebuild-swagger
+docker compose up rebuild-swagger
 ```
  
 #### Swagger codegen notes

--- a/ui/src/app/job-details/panels/panels.component.html
+++ b/ui/src/app/job-details/panels/panels.component.html
@@ -27,7 +27,6 @@
       </clr-tooltip-content>
     </clr-tooltip>
   </button>
-  <button *ngIf="canAbort()" (click)="abortJob()" class="close mat-raised-button">Abort job</button>
   <p class="job-id">
     ID: <input matInput id="job-id" value="{{ job.id }}" readonly="readonly" type="text">
     <button mat-icon-button (click)="copyJobIdToClipboard()" class="copy-button">
@@ -48,6 +47,7 @@
   <mat-card class="card">
     <mat-card-title>Status: <span class="job-status">{{ job.status }}</span>
       <clr-icon [attr.shape]="getStatusIcon(job.status)"></clr-icon>
+      <button *ngIf="canAbort()" (click)="abortJob()" class="close mat-raised-button">Abort job</button>
     </mat-card-title>
     <mat-card-content>
       <p><b>

--- a/ui/src/app/job-details/panels/panels.component.html
+++ b/ui/src/app/job-details/panels/panels.component.html
@@ -43,11 +43,10 @@
       <span *ngIf="job.labels[l]">{{ l + ': '}}<b>{{ job.labels[l] }}</b></span>
     </span>
   </div>
-
+  <button *ngIf="canAbort()" (click)="abortJob()" class="close mat-raised-button">Abort job</button>
   <mat-card class="card">
     <mat-card-title>Status: <span class="job-status">{{ job.status }}</span>
       <clr-icon [attr.shape]="getStatusIcon(job.status)"></clr-icon>
-      <button *ngIf="canAbort()" (click)="abortJob()" class="close mat-raised-button">Abort job</button>
     </mat-card-title>
     <mat-card-content>
       <p><b>


### PR DESCRIPTION
Abort and "Go back" buttons are in the same place in the job manager UI
A user can easily accidentally hit the abort button when trying to go back

(Also updated the readme because docker-compose is deprecated)