### PR TITLE
AN-617 Support alternate GCP Batch logs policy

### DIFF
--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -6,7 +6,7 @@
       </clr-tooltip-content>
     </a>
   </clr-tooltip>
-  <mat-icon *ngIf="!getResourceUrl(backendLog)" svgIcon="cloud-file" class="disabled"></mat-icon>
+  <mat-icon *ngIf="!getResourceUrl(backendLog) && !hasExternalLogs()" svgIcon="cloud-file" class="disabled"></mat-icon>
   <clr-tooltip *ngIf="getResourceUrl(backendLog)">
     <button class="log-item backend-log-button" (click)="showOrLinkTo($event, backendLog)">
       <mat-icon clrTooltipTrigger svgIcon="cloud-file"></mat-icon>
@@ -14,6 +14,14 @@
         <span>backend log</span>
       </clr-tooltip-content>
     </button>
+  </clr-tooltip>
+  <clr-tooltip *ngIf="!!hasExternalLogs() && !getResourceUrl(backendLog)">
+    <a class="log-item backend-log-button" [href]="getExternalLogsUrl()" target="_blank" (click)="$event.stopPropagation()">
+      <mat-icon clrTooltipTrigger svgIcon="cloud-file"></mat-icon>
+      <clr-tooltip-content clrPosition="top-left" clrSize="xs" *clrIfOpen>
+        <span>backend log</span>
+      </clr-tooltip-content>
+    </a>
   </clr-tooltip>
   <clr-icon *ngIf="!getDirectoryUrl(directory)" shape="folder" class="is-solid disabled"></clr-icon>
   <clr-tooltip *ngIf="getDirectoryUrl(directory)">

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
@@ -126,6 +126,16 @@ describe('JobDebugIconsComponent', () => {
     expect(de.queryAll(By.css('a.operation-details-button'))[0].nativeElement.href).toEqual(expectedUrl);
   }));
 
+  it('should link to the right location for GCP Batch logs', async(() => {
+    fixture.detectChanges();
+    testComponent.jobDebugIconsComponent.operationId = "projects/my-nice-project/locations/the-moon/jobs/job-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    testComponent.job.backendLog = "";
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    let expectedUrl = "https://console.cloud.google.com/batch/jobsDetail/regions/the-moon/jobs/job-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/logs?project=my-nice-project";
+    expect(de.queryAll(By.css('a.backend-log-button'))[0].nativeElement.href).toEqual(expectedUrl);
+  }));
+
   @Component({
     selector: 'jm-test-debug-icons-component',
     template: `<jm-debug-icons [displayMessage]="false"

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
@@ -92,6 +92,12 @@ export class JobDebugIconsComponent implements OnInit {
     return this.getOperationalDetailsUrl() != '';
   }
 
+  // Corresponds to running with the Google Batch backend. We link directly to the GCP console
+  // to show users backend logs. 
+  hasExternalLogs(): boolean {
+    return this.getExternalLogsUrl() != '';
+  }
+
   showOrLinkTo(e: MouseEvent, url: string): void {
     e.stopPropagation();
     if (this.hasContents(this.getFileName(url))) {
@@ -109,20 +115,28 @@ export class JobDebugIconsComponent implements OnInit {
     }
   }
 
-  // If this is a GCP Batch operation, transform the operation id into a URL to the Batch job details page.
+  // If this is a GCP Batch operation, transform the operation id into a URL to the appropriate tab on the Batch job details page.
   // Example input: projects/broad-dsde-cromwell-dev/locations/us-central1/jobs/job-1a4f7cff-3f17-49bf-b9ef-48b8b09c0f39
-  // Example output: https://console.cloud.google.com/batch/jobsDetail/regions/us-central1/jobs/job-1a4f7cff-3f17-49bf-b9ef-48b8b09c0f39/details?project=broad-dsde-cromwell-dev
-  getOperationalDetailsUrl(): string {
+  // Example output: https://console.cloud.google.com/batch/jobsDetail/regions/us-central1/jobs/job-1a4f7cff-3f17-49bf-b9ef-48b8b09c0f39/{TAB_NAME}?project=broad-dsde-cromwell-dev  
+  getGcpBatchUrlJobUrl(tabName: string): string {
     var match = this.gcpBatchOperationIdRegex.exec(this.operationId);
     if (match != null) {
       var projectId = match.groups.projectId;
       var location = match.groups.location;
       var batchJobId = match.groups.batchJobId;
-      return `https://console.cloud.google.com/batch/jobsDetail/regions/${location}/jobs/job-${batchJobId}/details?project=${projectId}`;
+      return `https://console.cloud.google.com/batch/jobsDetail/regions/${location}/jobs/job-${batchJobId}/${tabName}?project=${projectId}`;
     }
     else {
       return '';
     }
+  }
+
+  getOperationalDetailsUrl(): string {
+    return this.getGcpBatchUrlJobUrl('details');
+  }
+
+  getExternalLogsUrl(): string {
+    return this.getGcpBatchUrlJobUrl('logs');
   }
 
   showOperationDetails(e: MouseEvent): void {


### PR DESCRIPTION
When there is no backend log file (depends on https://github.com/broadinstitute/cromwell/pull/7765), and the task is a GCP Batch task, link to GCP Batch job logs explorer from backend log icon.