### PR TITLE
AN-635 Fix log icon

### DIFF
--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.html
@@ -6,7 +6,7 @@
       </clr-tooltip-content>
     </a>
   </clr-tooltip>
-  <mat-icon *ngIf="!getResourceUrl(backendLog) && !hasExternalLogs()" svgIcon="cloud-file" class="disabled"></mat-icon>
+  <mat-icon *ngIf="!getResourceUrl(backendLog) && !hasExternalLogs()" svgIcon="cloud-file" class="backend-log-button disabled"></mat-icon>
   <clr-tooltip *ngIf="getResourceUrl(backendLog)">
     <button class="log-item backend-log-button" (click)="showOrLinkTo($event, backendLog)">
       <mat-icon clrTooltipTrigger svgIcon="cloud-file"></mat-icon>

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
@@ -136,6 +136,12 @@ describe('JobDebugIconsComponent', () => {
     expect(de.queryAll(By.css('a.backend-log-button'))[0].nativeElement.href).toEqual(expectedUrl);
   }));
 
+  it('should disable the log icon when backend log datum exists but the file cannot be loaded', async(() => {
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement;
+    expect(de.queryAll(By.css('.backend-log-button'))[0].nativeElement.classList).toContain('disabled');
+  }));
+
   @Component({
     selector: 'jm-test-debug-icons-component',
     template: `<jm-debug-icons [displayMessage]="false"

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.spec.ts
@@ -138,6 +138,9 @@ describe('JobDebugIconsComponent', () => {
 
   it('should disable the log icon when backend log datum exists but the file cannot be loaded', async(() => {
     fixture.detectChanges();
+    testComponent.jobDebugIconsComponent.operationId = "projects/my-nice-project/locations/the-moon/jobs/job-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    testComponent.job.backendLog = "f00bar"; // exists but not valid
+    fixture.detectChanges();
     let de: DebugElement = fixture.debugElement;
     expect(de.queryAll(By.css('.backend-log-button'))[0].nativeElement.classList).toContain('disabled');
   }));

--- a/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
+++ b/ui/src/app/job-details/common/debug-icons/debug-icons.component.ts
@@ -95,7 +95,7 @@ export class JobDebugIconsComponent implements OnInit {
   // Corresponds to running with the Google Batch backend. We link directly to the GCP console
   // to show users backend logs. 
   hasExternalLogs(): boolean {
-    return this.getExternalLogsUrl() != '';
+    return this.getExternalLogsUrl() != '' && !this.backendLog;
   }
 
   showOrLinkTo(e: MouseEvent, url: string): void {


### PR DESCRIPTION
Fixes a bug introduced in #800, in which the logs icon linked to Batch cloud log in cases where the backend log metadata item existed, but the file didn't exist or couldn't be read.