### PR TITLE
CTM-516 Update urllib3 to 2.7.0

### DIFF
--- a/servers/cromwell/requirements.txt
+++ b/servers/cromwell/requirements.txt
@@ -22,6 +22,6 @@ requests==2.32.5
 six==1.11.0
 swagger-spec-validator==2.7.6
 typing==3.6.1
-urllib3==2.6.3
+urllib3==2.7.0
 Werkzeug==3.0.6
 uvicorn==0.32.1


### PR DESCRIPTION
Resolves a high-severity security finding by bumping `urllib3` 2.6.3 → 2.7.0 (latest release, published 2026-05-07) in `servers/cromwell/requirements.txt`.

Compatible with the pinned `requests==2.32.5`, which requires `urllib3<3,>=1.21.1`. Follows the pattern of the prior bump in #803 (CTM-324).

🤖 Generated with [Claude Code](https://claude.com/claude-code)